### PR TITLE
feat: 파일 헤더 판별 / 사전 샘플링 / 스냅샷 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@
 
 #vcpkg
 vcpkg/
+
+src/engine/test_*.bin
+src/engine/test_*.delta
+src/engine/test_delta.exe
+src/engine/test.delta

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(dgit
     src/cli/main.cpp
     src/vcs/vcs.cpp
     src/engine/delta.cpp
+    src/engine/format.cpp
 )
 
 target_include_directories(dgit PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(dgit)
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(OpenSSL REQUIRED)
+find_package(zstd REQUIRED)
 
 add_executable(dgit
     src/cli/main.cpp
@@ -18,4 +19,7 @@ target_include_directories(dgit PRIVATE
     src/cli
 )
 
-target_link_libraries(dgit PRIVATE OpenSSL::Crypto)
+target_link_libraries(dgit PRIVATE
+    OpenSSL::Crypto
+    zstd::libzstd_shared
+)

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-// VCS ���� ������ �Լ����� ����ϱ� ���� ��� ���� ����
+// VCS 엔진 계층의 함수들을 사용하기 위한 헤더 파일 포함
 #include "../vcs/vcs.h"
 
 #include "../engine/format.h"
@@ -13,17 +13,17 @@ namespace fs = std::filesystem;
 
 namespace {
 
-    // ���� �۾� ���� ���丮�� ���� ��θ� ��ȯ�ϴ� �Լ�
+    // 현재 작업 중인 디렉토리의 절대 경로를 반환하는 함수
     std::string current_repo_path() {
         return fs::current_path().string();
     }
 
-    // ������ ��ο� ".vcs" ������ �����ϴ��� Ȯ���Ͽ� dgit ����� ���θ� �Ǻ��ϴ� �Լ�
+    // 지정된 경로에 ".vcs" 폴더가 존재하는지 확인하여 dgit 저장소 여부를 판별하는 함수
     bool is_dgit_repository(const std::string& repo_path) {
         return fs::exists(fs::path(repo_path) / ".vcs");
     }
 
-    // ����ڰ� 'dgit'�� �Է��ϰų� '--help'�� �Է����� �� ��µǴ� ��ü ����
+    // 사용자가 'dgit'만 입력하거나 '--help'를 입력했을 때 출력되는 전체 도움말
     void print_general_help() {
         std::cout
             << "usage: dgit <command> [<args>]\n\n"
@@ -37,7 +37,7 @@ namespace {
             << "Use 'dgit <command> --help' for more information on a command.\n";
     }
 
-    // Ư�� ���ɾ�(��: 'dgit commit --help')�� ���� �� ������ ����ϴ� �Լ�
+    // 특정 명령어(예: 'dgit commit --help')에 대한 상세 도움말을 출력하는 함수
     void print_command_help(const std::string& command) {
         if (command == "init") {
             std::cout << "usage: dgit init\n\n"
@@ -68,21 +68,21 @@ namespace {
         }
     }
 
-    // �ش� ���ɾ ����Ǳ� ���� �����(.vcs ����)�� �ݵ�� �����ؾ� �ϴ��� ���θ� ��ȯ
+    // 해당 명령어가 실행되기 전에 저장소(.vcs 폴더)가 반드시 존재해야 하는지 여부를 반환
     bool needs_repository(const std::string& command) {
         return command == "add" || command == "commit" || command == "log" ||
             command == "checkout" || command == "diff";
     }
 
-    // �߸��� ���ɾ� ���ڰ� ������ �� ���� �޽����� �ùٸ� ������ ����ϰ� ���� �ڵ�(1)�� ��ȯ
+    // 잘못된 명령어 인자가 들어왔을 때 에러 메시지와 올바른 사용법을 출력하고 에러 코드(1)를 반환
     int fail_usage(const std::string& message, const std::string& usage) {
         std::cerr << "dgit: " << message << "\n";
         std::cerr << "usage: " << usage << "\n";
         return 1;
     }
 
-    // "commit", "-m", "hello", "world" ó�� �и��� ���� �迭�� 
-    // "hello world" �ϳ��� ���Ⱑ ���Ե� ���ڿ��� �����ִ� ��ƿ��Ƽ �Լ�
+    // "commit", "-m", "hello", "world" 처럼 분리된 인자 배열을 
+    // "hello world" 하나의 띄어쓰기가 포함된 문자열로 합쳐주는 유틸리티 함수
     std::string join_args(const std::vector<std::string>& args, std::size_t start) {
         std::string result;
         for (std::size_t i = start; i < args.size(); ++i) {
@@ -94,7 +94,7 @@ namespace {
         return result;
     }
 
-    // .vcs/index ������ �о� ù ��°�� ���� ���� ������ �̸��� ��ȯ�ϴ� �Լ�
+    // .vcs/index 파일을 읽어 첫 번째로 추적 중인 파일의 이름을 반환하는 함수
     std::string read_tracked_file(const std::string& repo_path) {
         const fs::path index_path = fs::path(repo_path) / ".vcs" / "index";
         std::ifstream index_file(index_path);
@@ -105,7 +105,7 @@ namespace {
 
         std::string line;
         while (std::getline(index_file, line)) {
-            // Windows ȯ���� ���� ����(\r) ó��
+            // Windows 환경의 개행 문자(\r) 처리
             if (!line.empty() && line.back() == '\r') {
                 line.pop_back();
             }
@@ -117,7 +117,7 @@ namespace {
         return "";
     }
 
-    // 'dgit init' ���ɾ� ó��
+    // 'dgit init' 명령어 처리
     int handle_init(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("init");
@@ -127,7 +127,7 @@ namespace {
             return fail_usage("init takes no arguments", "dgit init");
         }
 
-        // VCS ���̾��� �ʱ�ȭ �Լ� ȣ��
+        // VCS 레이어의 초기화 함수 호출
         const int result = init_repository(repo_path);
         if (result != 0) {
             std::cerr << "fatal: dgit repository already exists or could not be initialized\n";
@@ -138,7 +138,7 @@ namespace {
         return 0;
     }
 
-    // 'dgit add <file>' ���ɾ� ó��
+    // 'dgit add <file>' 명령어 처리
     int handle_add(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("add");
@@ -154,19 +154,19 @@ namespace {
         const std::string filepath = args[2];
         const fs::path file_path(filepath);
 
-        // ���� ���� ���� �˻�
+        // 파일 존재 여부 검사
         if (!fs::exists(file_path)) {
             std::cerr << "fatal: pathspec '" << filepath << "' did not match any files\n";
             return 1;
         }
-        // ������ �߰��Ϸ��� �õ��ϴ� ��� ���� ó�� (���� MVP ���� �ƴ�)
+        // 폴더를 추가하려고 시도하는 경우 에러 처리 (현재 MVP 범위 아님)
         if (fs::is_directory(file_path)) {
             std::cerr << "fatal: pathspec '" << filepath
                 << "' is a directory; this MVP accepts exactly one file\n";
             return 1;
         }
 
-        // VCS ���̾��� add_file �Լ� ȣ��
+        // VCS 레이어의 add_file 함수 호출
         const int result = add_file(repo_path, filepath);
         if (result != 0) {
             std::cerr << "fatal: failed to add '" << filepath << "'\n";
@@ -177,13 +177,13 @@ namespace {
         return 0;
     }
 
-    // 'dgit commit -m "message"' ���ɾ� ó��
+    // 'dgit commit -m "message"' 명령어 처리
     int handle_commit(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("commit");
             return 0;
         }
-        // �ʼ� �ɼ� �˻�
+        // 필수 옵션 검사
         if (args.size() < 4) {
             return fail_usage("switch 'm' requires a value", "dgit commit -m <message>");
         }
@@ -196,7 +196,7 @@ namespace {
             return fail_usage("empty commit message", "dgit commit -m <message>");
         }
 
-        // ���� ���� ������ �ִ��� Ȯ��
+        // 추적 중인 파일이 있는지 확인
         const std::string target_file = read_tracked_file(repo_path);
         if (target_file.empty()) {
             std::cerr << "fatal: no tracked files. Use 'dgit add <file>' first.\n";
@@ -213,19 +213,19 @@ namespace {
             std::cout << "note: binary delta will be created\n";
         }   
 
-        // VCS ���̾��� commit �Լ� ȣ�� �� ���(commit_id) ��ȯ
+        // VCS 레이어의 commit 함수 호출 및 결과(commit_id) 반환
         const std::string commit_id = commit(repo_path, message, target_file);
         if (commit_id.empty()) {
             std::cerr << "fatal: failed to create commit\n";
             return 1;
         }
 
-        // ���� �� ª�� �ؽð�(�� 8�ڸ�)�� �޽��� ���
+        // 성공 시 짧은 해시값(앞 8자리)과 메시지 출력
         std::cout << "[dgit " << commit_id.substr(0, 8) << "] " << message << "\n";
         return 0;
     }
 
-    // 'dgit log' ���ɾ� ó��
+    // 'dgit log' 명령어 처리
     int handle_log(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("log");
@@ -235,12 +235,12 @@ namespace {
             return fail_usage("log takes no arguments", "dgit log");
         }
 
-        // VCS ���̾��� log �Լ� ȣ�� (���ο��� ��ü������ ��� ���)
+        // VCS 레이어의 log 함수 호출 (내부에서 자체적으로 출력 담당)
         log(repo_path);
         return 0;
     }
 
-    // 'dgit checkout <commit_id>' ���ɾ� ó��
+    // 'dgit checkout <commit_id>' 명령어 처리
     int handle_checkout(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("checkout");
@@ -255,7 +255,7 @@ namespace {
 
         const std::string commit_id = args[2];
 
-        // VCS ���̾��� checkout �Լ� ȣ��
+        // VCS 레이어의 checkout 함수 호출
         const int result = checkout(repo_path, commit_id);
         if (result != 0) {
             std::cerr << "fatal: reference is not a commit: " << commit_id << "\n";
@@ -266,7 +266,7 @@ namespace {
         return 0;
     }
 
-    // 'dgit diff' ���ɾ� ó�� (MVP �ܰ迡���� �������̽��� ����)
+    // 'dgit diff' 명령어 처리 (MVP 단계에서는 인터페이스만 제공)
     int handle_diff(const std::vector<std::string>& args) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("diff");
@@ -282,27 +282,27 @@ namespace {
 
 }  // namespace
 
-// ���α׷��� ���� ������
+// 프로그램의 메인 진입점
 int main(int argc, char* argv[]) {
-    // �ü���� ������ ���� �迭(argv)�� C++ ����(vector)�� ��ȯ�Ͽ� ����ϱ� ���ϰ� ����
+    // 운영체제가 전달한 인자 배열(argv)을 C++ 벡터(vector)로 변환하여 사용하기 편하게 만듦
     const std::vector<std::string> args(argv, argv + argc);
 
-    // ���ڰ� �ƹ��͵� ���� 'dgit'�� �ԷµǾ��� ��
+    // 인자가 아무것도 없이 'dgit'만 입력되었을 때
     if (argc == 1) {
         print_general_help();
         return 1;
     }
 
-    // ù ��° ����(��: init, commit) ����
+    // 첫 번째 인자(예: init, commit) 추출
     const std::string command = args[1];
 
-    // ��ü ���� ��û ó��
+    // 전체 도움말 요청 처리
     if (command == "--help" || command == "help") {
         print_general_help();
         return 0;
     }
 
-    // Ư�� ���ɾ ���� ���� ��û ó�� (��: dgit add --help)
+    // 특정 명령어에 대한 도움말 요청 처리 (예: dgit add --help)
     if (args.size() == 3 && args[2] == "--help") {
         print_command_help(command);
         return 0;
@@ -310,13 +310,13 @@ int main(int argc, char* argv[]) {
 
     const std::string repo_path = current_repo_path();
 
-    // init ���ɾ �����ϰ��� �׻� .vcs ������ �����ϴ��� ���� Ȯ��
+    // init 명령어를 제외하고는 항상 .vcs 폴더가 존재하는지 먼저 확인
     if (needs_repository(command) && !is_dgit_repository(repo_path)) {
         std::cerr << "fatal: not a dgit repository (or any of the parent directories): .vcs\n";
         return 1;
     }
 
-    // �Էµ� ���ɾ ���� �ش�Ǵ� �ڵ鷯 �Լ��� ���� (�����)
+    // 입력된 명령어에 따라 해당되는 핸들러 함수로 연결 (라우팅)
     if (command == "init") {
         return handle_init(args, repo_path);
     }
@@ -336,7 +336,7 @@ int main(int argc, char* argv[]) {
         return handle_diff(args);
     }
 
-    // ������ ���ǵ��� ���� ���ɾ �ԷµǾ��� ���� ���� ó��
+    // 사전에 정의되지 않은 명령어가 입력되었을 때의 예외 처리
     std::cerr << "dgit: '" << command << "' is not a dgit command. See 'dgit --help'.\n";
     return 1;
 }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -4,24 +4,26 @@
 #include <string>
 #include <vector>
 
-// VCS ¿£Áø °èÃşÀÇ ÇÔ¼öµéÀ» »ç¿ëÇÏ±â À§ÇÑ Çì´õ ÆÄÀÏ Æ÷ÇÔ
+// VCS ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Ô¼ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½Ï±ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 #include "../vcs/vcs.h"
+
+#include "../engine/format.h"
 
 namespace fs = std::filesystem;
 
 namespace {
 
-    // ÇöÀç ÀÛ¾÷ ÁßÀÎ µğ·ºÅä¸®ÀÇ Àı´ë °æ·Î¸¦ ¹İÈ¯ÇÏ´Â ÇÔ¼ö
+    // ï¿½ï¿½ï¿½ï¿½ ï¿½Û¾ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ä¸®ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Î¸ï¿½ ï¿½ï¿½È¯ï¿½Ï´ï¿½ ï¿½Ô¼ï¿½
     std::string current_repo_path() {
         return fs::current_path().string();
     }
 
-    // ÁöÁ¤µÈ °æ·Î¿¡ ".vcs" Æú´õ°¡ Á¸ÀçÇÏ´ÂÁö È®ÀÎÇÏ¿© dgit ÀúÀå¼Ò ¿©ºÎ¸¦ ÆÇº°ÇÏ´Â ÇÔ¼ö
+    // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Î¿ï¿½ ".vcs" ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ï´ï¿½ï¿½ï¿½ È®ï¿½ï¿½ï¿½Ï¿ï¿½ dgit ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Î¸ï¿½ ï¿½Çºï¿½ï¿½Ï´ï¿½ ï¿½Ô¼ï¿½
     bool is_dgit_repository(const std::string& repo_path) {
         return fs::exists(fs::path(repo_path) / ".vcs");
     }
 
-    // »ç¿ëÀÚ°¡ 'dgit'¸¸ ÀÔ·ÂÇÏ°Å³ª '--help'¸¦ ÀÔ·ÂÇßÀ» ¶§ Ãâ·ÂµÇ´Â ÀüÃ¼ µµ¿ò¸»
+    // ï¿½ï¿½ï¿½ï¿½Ú°ï¿½ 'dgit'ï¿½ï¿½ ï¿½Ô·ï¿½ï¿½Ï°Å³ï¿½ '--help'ï¿½ï¿½ ï¿½Ô·ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ÂµÇ´ï¿½ ï¿½ï¿½Ã¼ ï¿½ï¿½ï¿½ï¿½
     void print_general_help() {
         std::cout
             << "usage: dgit <command> [<args>]\n\n"
@@ -35,7 +37,7 @@ namespace {
             << "Use 'dgit <command> --help' for more information on a command.\n";
     }
 
-    // Æ¯Á¤ ¸í·É¾î(¿¹: 'dgit commit --help')¿¡ ´ëÇÑ »ó¼¼ µµ¿ò¸»À» Ãâ·ÂÇÏ´Â ÇÔ¼ö
+    // Æ¯ï¿½ï¿½ ï¿½ï¿½ï¿½É¾ï¿½(ï¿½ï¿½: 'dgit commit --help')ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½Ï´ï¿½ ï¿½Ô¼ï¿½
     void print_command_help(const std::string& command) {
         if (command == "init") {
             std::cout << "usage: dgit init\n\n"
@@ -66,21 +68,21 @@ namespace {
         }
     }
 
-    // ÇØ´ç ¸í·É¾î°¡ ½ÇÇàµÇ±â Àü¿¡ ÀúÀå¼Ò(.vcs Æú´õ)°¡ ¹İµå½Ã Á¸ÀçÇØ¾ß ÇÏ´ÂÁö ¿©ºÎ¸¦ ¹İÈ¯
+    // ï¿½Ø´ï¿½ ï¿½ï¿½ï¿½É¾î°¡ ï¿½ï¿½ï¿½ï¿½Ç±ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½(.vcs ï¿½ï¿½ï¿½ï¿½)ï¿½ï¿½ ï¿½İµï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ø¾ï¿½ ï¿½Ï´ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Î¸ï¿½ ï¿½ï¿½È¯
     bool needs_repository(const std::string& command) {
         return command == "add" || command == "commit" || command == "log" ||
             command == "checkout" || command == "diff";
     }
 
-    // Àß¸øµÈ ¸í·É¾î ÀÎÀÚ°¡ µé¾î¿ÔÀ» ¶§ ¿¡·¯ ¸Ş½ÃÁö¿Í ¿Ã¹Ù¸¥ »ç¿ë¹ıÀ» Ãâ·ÂÇÏ°í ¿¡·¯ ÄÚµå(1)¸¦ ¹İÈ¯
+    // ï¿½ß¸ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½É¾ï¿½ ï¿½ï¿½ï¿½Ú°ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½Ş½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Ã¹Ù¸ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½Ï°ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½Úµï¿½(1)ï¿½ï¿½ ï¿½ï¿½È¯
     int fail_usage(const std::string& message, const std::string& usage) {
         std::cerr << "dgit: " << message << "\n";
         std::cerr << "usage: " << usage << "\n";
         return 1;
     }
 
-    // "commit", "-m", "hello", "world" Ã³·³ ºĞ¸®µÈ ÀÎÀÚ ¹è¿­À» 
-    // "hello world" ÇÏ³ªÀÇ ¶ç¾î¾²±â°¡ Æ÷ÇÔµÈ ¹®ÀÚ¿­·Î ÇÕÃÄÁÖ´Â À¯Æ¿¸®Æ¼ ÇÔ¼ö
+    // "commit", "-m", "hello", "world" Ã³ï¿½ï¿½ ï¿½Ğ¸ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½è¿­ï¿½ï¿½ 
+    // "hello world" ï¿½Ï³ï¿½ï¿½ï¿½ ï¿½ï¿½î¾²ï¿½â°¡ ï¿½ï¿½ï¿½Ôµï¿½ ï¿½ï¿½ï¿½Ú¿ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ö´ï¿½ ï¿½ï¿½Æ¿ï¿½ï¿½Æ¼ ï¿½Ô¼ï¿½
     std::string join_args(const std::vector<std::string>& args, std::size_t start) {
         std::string result;
         for (std::size_t i = start; i < args.size(); ++i) {
@@ -92,7 +94,7 @@ namespace {
         return result;
     }
 
-    // .vcs/index ÆÄÀÏÀ» ÀĞ¾î Ã¹ ¹øÂ°·Î ÃßÀû ÁßÀÎ ÆÄÀÏÀÇ ÀÌ¸§À» ¹İÈ¯ÇÏ´Â ÇÔ¼ö
+    // .vcs/index ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Ğ¾ï¿½ Ã¹ ï¿½ï¿½Â°ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Ì¸ï¿½ï¿½ï¿½ ï¿½ï¿½È¯ï¿½Ï´ï¿½ ï¿½Ô¼ï¿½
     std::string read_tracked_file(const std::string& repo_path) {
         const fs::path index_path = fs::path(repo_path) / ".vcs" / "index";
         std::ifstream index_file(index_path);
@@ -103,7 +105,7 @@ namespace {
 
         std::string line;
         while (std::getline(index_file, line)) {
-            // Windows È¯°æÀÇ °³Çà ¹®ÀÚ(\r) Ã³¸®
+            // Windows È¯ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½(\r) Ã³ï¿½ï¿½
             if (!line.empty() && line.back() == '\r') {
                 line.pop_back();
             }
@@ -115,7 +117,7 @@ namespace {
         return "";
     }
 
-    // 'dgit init' ¸í·É¾î Ã³¸®
+    // 'dgit init' ï¿½ï¿½ï¿½É¾ï¿½ Ã³ï¿½ï¿½
     int handle_init(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("init");
@@ -125,7 +127,7 @@ namespace {
             return fail_usage("init takes no arguments", "dgit init");
         }
 
-        // VCS ·¹ÀÌ¾îÀÇ ÃÊ±âÈ­ ÇÔ¼ö È£Ãâ
+        // VCS ï¿½ï¿½ï¿½Ì¾ï¿½ï¿½ï¿½ ï¿½Ê±ï¿½È­ ï¿½Ô¼ï¿½ È£ï¿½ï¿½
         const int result = init_repository(repo_path);
         if (result != 0) {
             std::cerr << "fatal: dgit repository already exists or could not be initialized\n";
@@ -136,7 +138,7 @@ namespace {
         return 0;
     }
 
-    // 'dgit add <file>' ¸í·É¾î Ã³¸®
+    // 'dgit add <file>' ï¿½ï¿½ï¿½É¾ï¿½ Ã³ï¿½ï¿½
     int handle_add(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("add");
@@ -152,19 +154,19 @@ namespace {
         const std::string filepath = args[2];
         const fs::path file_path(filepath);
 
-        // ÆÄÀÏ Á¸Àç ¿©ºÎ °Ë»ç
+        // ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½Ë»ï¿½
         if (!fs::exists(file_path)) {
             std::cerr << "fatal: pathspec '" << filepath << "' did not match any files\n";
             return 1;
         }
-        // Æú´õ¸¦ Ãß°¡ÇÏ·Á°í ½ÃµµÇÏ´Â °æ¿ì ¿¡·¯ Ã³¸® (ÇöÀç MVP ¹üÀ§ ¾Æ´Ô)
+        // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ß°ï¿½ï¿½Ï·ï¿½ï¿½ï¿½ ï¿½Ãµï¿½ï¿½Ï´ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ Ã³ï¿½ï¿½ (ï¿½ï¿½ï¿½ï¿½ MVP ï¿½ï¿½ï¿½ï¿½ ï¿½Æ´ï¿½)
         if (fs::is_directory(file_path)) {
             std::cerr << "fatal: pathspec '" << filepath
                 << "' is a directory; this MVP accepts exactly one file\n";
             return 1;
         }
 
-        // VCS ·¹ÀÌ¾îÀÇ add_file ÇÔ¼ö È£Ãâ
+        // VCS ï¿½ï¿½ï¿½Ì¾ï¿½ï¿½ï¿½ add_file ï¿½Ô¼ï¿½ È£ï¿½ï¿½
         const int result = add_file(repo_path, filepath);
         if (result != 0) {
             std::cerr << "fatal: failed to add '" << filepath << "'\n";
@@ -175,13 +177,13 @@ namespace {
         return 0;
     }
 
-    // 'dgit commit -m "message"' ¸í·É¾î Ã³¸®
+    // 'dgit commit -m "message"' ï¿½ï¿½ï¿½É¾ï¿½ Ã³ï¿½ï¿½
     int handle_commit(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("commit");
             return 0;
         }
-        // ÇÊ¼ö ¿É¼Ç °Ë»ç
+        // ï¿½Ê¼ï¿½ ï¿½É¼ï¿½ ï¿½Ë»ï¿½
         if (args.size() < 4) {
             return fail_usage("switch 'm' requires a value", "dgit commit -m <message>");
         }
@@ -194,26 +196,36 @@ namespace {
             return fail_usage("empty commit message", "dgit commit -m <message>");
         }
 
-        // ÃßÀû ÁßÀÎ ÆÄÀÏÀÌ ÀÖ´ÂÁö È®ÀÎ
+        // ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Ö´ï¿½ï¿½ï¿½ È®ï¿½ï¿½
         const std::string target_file = read_tracked_file(repo_path);
         if (target_file.empty()) {
             std::cerr << "fatal: no tracked files. Use 'dgit add <file>' first.\n";
             return 1;
         }
 
-        // VCS ·¹ÀÌ¾îÀÇ commit ÇÔ¼ö È£Ãâ ¹× °á°ú(commit_id) ¹İÈ¯
+        // ì••ì¶• í¬ë§· ì—¬ë¶€ ì¶œë ¥
+        if (is_compressed_format(target_file))
+        {
+            std::cout << "note: compressed format detected, storing full copy\n";
+        }
+        else
+        {
+            std::cout << "note: binary delta will be created\n";
+        }   
+
+        // VCS ï¿½ï¿½ï¿½Ì¾ï¿½ï¿½ï¿½ commit ï¿½Ô¼ï¿½ È£ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½(commit_id) ï¿½ï¿½È¯
         const std::string commit_id = commit(repo_path, message, target_file);
         if (commit_id.empty()) {
             std::cerr << "fatal: failed to create commit\n";
             return 1;
         }
 
-        // ¼º°ø ½Ã ÂªÀº ÇØ½Ã°ª(¾Õ 8ÀÚ¸®)°ú ¸Ş½ÃÁö Ãâ·Â
+        // ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ Âªï¿½ï¿½ ï¿½Ø½Ã°ï¿½(ï¿½ï¿½ 8ï¿½Ú¸ï¿½)ï¿½ï¿½ ï¿½Ş½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½
         std::cout << "[dgit " << commit_id.substr(0, 8) << "] " << message << "\n";
         return 0;
     }
 
-    // 'dgit log' ¸í·É¾î Ã³¸®
+    // 'dgit log' ï¿½ï¿½ï¿½É¾ï¿½ Ã³ï¿½ï¿½
     int handle_log(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("log");
@@ -223,12 +235,12 @@ namespace {
             return fail_usage("log takes no arguments", "dgit log");
         }
 
-        // VCS ·¹ÀÌ¾îÀÇ log ÇÔ¼ö È£Ãâ (³»ºÎ¿¡¼­ ÀÚÃ¼ÀûÀ¸·Î Ãâ·Â ´ã´ç)
+        // VCS ï¿½ï¿½ï¿½Ì¾ï¿½ï¿½ï¿½ log ï¿½Ô¼ï¿½ È£ï¿½ï¿½ (ï¿½ï¿½ï¿½Î¿ï¿½ï¿½ï¿½ ï¿½ï¿½Ã¼ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½)
         log(repo_path);
         return 0;
     }
 
-    // 'dgit checkout <commit_id>' ¸í·É¾î Ã³¸®
+    // 'dgit checkout <commit_id>' ï¿½ï¿½ï¿½É¾ï¿½ Ã³ï¿½ï¿½
     int handle_checkout(const std::vector<std::string>& args, const std::string& repo_path) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("checkout");
@@ -243,7 +255,7 @@ namespace {
 
         const std::string commit_id = args[2];
 
-        // VCS ·¹ÀÌ¾îÀÇ checkout ÇÔ¼ö È£Ãâ
+        // VCS ï¿½ï¿½ï¿½Ì¾ï¿½ï¿½ï¿½ checkout ï¿½Ô¼ï¿½ È£ï¿½ï¿½
         const int result = checkout(repo_path, commit_id);
         if (result != 0) {
             std::cerr << "fatal: reference is not a commit: " << commit_id << "\n";
@@ -254,7 +266,7 @@ namespace {
         return 0;
     }
 
-    // 'dgit diff' ¸í·É¾î Ã³¸® (MVP ´Ü°è¿¡¼­´Â ÀÎÅÍÆäÀÌ½º¸¸ Á¦°ø)
+    // 'dgit diff' ï¿½ï¿½ï¿½É¾ï¿½ Ã³ï¿½ï¿½ (MVP ï¿½Ü°è¿¡ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ì½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½)
     int handle_diff(const std::vector<std::string>& args) {
         if (args.size() == 3 && args[2] == "--help") {
             print_command_help("diff");
@@ -270,27 +282,27 @@ namespace {
 
 }  // namespace
 
-// ÇÁ·Î±×·¥ÀÇ ¸ŞÀÎ ÁøÀÔÁ¡
+// ï¿½ï¿½ï¿½Î±×·ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 int main(int argc, char* argv[]) {
-    // ¿î¿µÃ¼Á¦°¡ Àü´ŞÇÑ ÀÎÀÚ ¹è¿­(argv)À» C++ º¤ÅÍ(vector)·Î º¯È¯ÇÏ¿© »ç¿ëÇÏ±â ÆíÇÏ°Ô ¸¸µê
+    // ï¿½î¿µÃ¼ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½è¿­(argv)ï¿½ï¿½ C++ ï¿½ï¿½ï¿½ï¿½(vector)ï¿½ï¿½ ï¿½ï¿½È¯ï¿½Ï¿ï¿½ ï¿½ï¿½ï¿½ï¿½Ï±ï¿½ ï¿½ï¿½ï¿½Ï°ï¿½ ï¿½ï¿½ï¿½ï¿½
     const std::vector<std::string> args(argv, argv + argc);
 
-    // ÀÎÀÚ°¡ ¾Æ¹«°Íµµ ¾øÀÌ 'dgit'¸¸ ÀÔ·ÂµÇ¾úÀ» ¶§
+    // ï¿½ï¿½ï¿½Ú°ï¿½ ï¿½Æ¹ï¿½ï¿½Íµï¿½ ï¿½ï¿½ï¿½ï¿½ 'dgit'ï¿½ï¿½ ï¿½Ô·ÂµÇ¾ï¿½ï¿½ï¿½ ï¿½ï¿½
     if (argc == 1) {
         print_general_help();
         return 1;
     }
 
-    // Ã¹ ¹øÂ° ÀÎÀÚ(¿¹: init, commit) ÃßÃâ
+    // Ã¹ ï¿½ï¿½Â° ï¿½ï¿½ï¿½ï¿½(ï¿½ï¿½: init, commit) ï¿½ï¿½ï¿½ï¿½
     const std::string command = args[1];
 
-    // ÀüÃ¼ µµ¿ò¸» ¿äÃ» Ã³¸®
+    // ï¿½ï¿½Ã¼ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Ã» Ã³ï¿½ï¿½
     if (command == "--help" || command == "help") {
         print_general_help();
         return 0;
     }
 
-    // Æ¯Á¤ ¸í·É¾î¿¡ ´ëÇÑ µµ¿ò¸» ¿äÃ» Ã³¸® (¿¹: dgit add --help)
+    // Æ¯ï¿½ï¿½ ï¿½ï¿½ï¿½É¾î¿¡ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Ã» Ã³ï¿½ï¿½ (ï¿½ï¿½: dgit add --help)
     if (args.size() == 3 && args[2] == "--help") {
         print_command_help(command);
         return 0;
@@ -298,13 +310,13 @@ int main(int argc, char* argv[]) {
 
     const std::string repo_path = current_repo_path();
 
-    // init ¸í·É¾î¸¦ Á¦¿ÜÇÏ°í´Â Ç×»ó .vcs Æú´õ°¡ Á¸ÀçÇÏ´ÂÁö ¸ÕÀú È®ÀÎ
+    // init ï¿½ï¿½ï¿½É¾î¸¦ ï¿½ï¿½ï¿½ï¿½ï¿½Ï°ï¿½ï¿½ï¿½ ï¿½×»ï¿½ .vcs ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ï´ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ È®ï¿½ï¿½
     if (needs_repository(command) && !is_dgit_repository(repo_path)) {
         std::cerr << "fatal: not a dgit repository (or any of the parent directories): .vcs\n";
         return 1;
     }
 
-    // ÀÔ·ÂµÈ ¸í·É¾î¿¡ µû¶ó ÇØ´çµÇ´Â ÇÚµé·¯ ÇÔ¼ö·Î ¿¬°á (¶ó¿ìÆÃ)
+    // ï¿½Ô·Âµï¿½ ï¿½ï¿½ï¿½É¾î¿¡ ï¿½ï¿½ï¿½ï¿½ ï¿½Ø´ï¿½Ç´ï¿½ ï¿½Úµé·¯ ï¿½Ô¼ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ (ï¿½ï¿½ï¿½ï¿½ï¿½)
     if (command == "init") {
         return handle_init(args, repo_path);
     }
@@ -324,7 +336,7 @@ int main(int argc, char* argv[]) {
         return handle_diff(args);
     }
 
-    // »çÀü¿¡ Á¤ÀÇµÇÁö ¾ÊÀº ¸í·É¾î°¡ ÀÔ·ÂµÇ¾úÀ» ¶§ÀÇ ¿¹¿Ü Ã³¸®
+    // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Çµï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½É¾î°¡ ï¿½Ô·ÂµÇ¾ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ Ã³ï¿½ï¿½
     std::cerr << "dgit: '" << command << "' is not a dgit command. See 'dgit --help'.\n";
     return 1;
 }

--- a/src/engine/format.cpp
+++ b/src/engine/format.cpp
@@ -1,0 +1,141 @@
+#include "format.h"
+#include <fstream>
+#include <cstdint>
+#include <cstring>
+
+static const size_t SAMPLE_BLOCK = 16 * 1024;        // 16KB 블록 단위
+static const size_t SAMPLE_REGION = 100 * 1024 * 1024; // 100MB 구간
+
+// 앞 16바이트만 읽으면 모든 헤더 판별 가능
+static const size_t HEADER_SIZE = 16;
+
+// 압축 포맷 헤더 테이블
+// { 시작 오프셋, 바이트 배열, 길이 }
+struct MagicEntry {
+    size_t      offset;
+    uint8_t     magic[8];
+    size_t      len;
+};
+
+static const MagicEntry COMPRESSED_FORMATS[] = {
+    { 0, { 0xFF, 0xD8, 0xFF },             3 },  // JPG
+    { 0, { 0x89, 0x50, 0x4E, 0x47 },       4 },  // PNG
+    { 0, { 0x47, 0x49, 0x46 },             3 },  // GIF
+    { 0, { 0x50, 0x4B, 0x03, 0x04 },       4 },  // ZIP
+    { 0, { 0x1F, 0x8B },                   2 },  // GZIP
+    { 0, { 0x28, 0xB5, 0x2F, 0xFD },       4 },  // ZSTD
+    { 4, { 0x66, 0x74, 0x79, 0x70 },       4 },  // MP4 ("ftyp" box)
+};
+
+bool is_compressed_format(const std::string& filepath)
+{
+    // 헤더 16바이트 읽기
+    std::ifstream f(filepath, std::ios::binary);
+    if (!f.is_open())
+        return false;
+
+    uint8_t header[HEADER_SIZE] = {};
+    f.read(reinterpret_cast<char*>(header), HEADER_SIZE);
+    const size_t bytes_read = static_cast<size_t>(f.gcount());
+
+    // 헤더 테이블과 비교
+    for (const auto& entry : COMPRESSED_FORMATS) {
+        if (entry.offset + entry.len > bytes_read)
+            continue;
+        if (memcmp(header + entry.offset, entry.magic, entry.len) == 0)
+            return true;
+    }
+
+    return false;  // 해당 없으면 비압축 → delta 대상
+}
+
+
+// 특정 오프셋부터 블록 단위로 읽어서 변경된 블록 수 반환
+static size_t count_changed_blocks(std::ifstream& prev_f,
+                                   std::ifstream& curr_f,
+                                   uint64_t offset,
+                                   uint64_t region_size)
+{
+    prev_f.seekg(offset);
+    curr_f.seekg(offset);
+
+    uint8_t prev_buf[SAMPLE_BLOCK];
+    uint8_t curr_buf[SAMPLE_BLOCK];
+
+    size_t changed = 0;
+    size_t scanned = 0;
+
+    while (scanned < region_size)
+    {
+        prev_f.read(reinterpret_cast<char*>(prev_buf), SAMPLE_BLOCK);
+        curr_f.read(reinterpret_cast<char*>(curr_buf), SAMPLE_BLOCK);
+
+        size_t prev_n = static_cast<size_t>(prev_f.gcount());
+        size_t curr_n = static_cast<size_t>(curr_f.gcount());
+
+        if (prev_n == 0 || curr_n == 0)
+            break;
+
+        size_t n = std::min(prev_n, curr_n);
+        if (memcmp(prev_buf, curr_buf, n) != 0)
+            ++changed;
+
+        scanned += n;
+    }
+
+    return changed;
+}
+
+bool should_use_full_copy(const std::string& prev_path,
+                          const std::string& curr_path,
+                          double threshold)
+{
+    std::ifstream prev_f(prev_path, std::ios::binary);
+    std::ifstream curr_f(curr_path, std::ios::binary);
+
+    if (!prev_f.is_open() || !curr_f.is_open())
+        return false; // 열기 실패 시 delta 시도
+
+    // 파일 크기 확인
+    prev_f.seekg(0, std::ios::end);
+    curr_f.seekg(0, std::ios::end);
+    uint64_t prev_size = static_cast<uint64_t>(prev_f.tellg());
+    uint64_t curr_size = static_cast<uint64_t>(curr_f.tellg());
+
+    // 파일 크기 차이가 50% 이상이면 바로 전체 저장
+    double size_ratio = static_cast<double>(curr_size) /
+                        static_cast<double>(prev_size > 0 ? prev_size : 1);
+    if (size_ratio > 1.5 || size_ratio < 0.5)
+        return true;
+
+    uint64_t file_size = std::min(prev_size, curr_size);
+
+    // 샘플링 구간 3개: 앞 / 중간 / 뒤
+    uint64_t mid_offset  = (file_size / 2 > SAMPLE_REGION)
+                           ? file_size / 2 - SAMPLE_REGION / 2 : 0;
+    uint64_t tail_offset = (file_size > SAMPLE_REGION)
+                           ? file_size - SAMPLE_REGION : 0;
+
+    size_t changed = 0;
+    size_t total   = 0;
+
+    // 앞 구간
+    auto count_region = [&](uint64_t offset) {
+        uint64_t region = std::min(static_cast<uint64_t>(SAMPLE_REGION), file_size);
+        size_t blocks = (region + SAMPLE_BLOCK - 1) / SAMPLE_BLOCK;
+        changed += count_changed_blocks(prev_f, curr_f, offset, region);
+        total   += blocks;
+    };
+
+    count_region(0);
+    count_region(mid_offset);
+    count_region(tail_offset);
+
+    if (total == 0)
+        return false;
+
+    double change_ratio = static_cast<double>(changed) /
+                          static_cast<double>(total);
+
+    return change_ratio >= threshold;
+}

--- a/src/engine/format.cpp
+++ b/src/engine/format.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <cstdint>
 #include <cstring>
+#include <iostream>
 
 static const size_t SAMPLE_BLOCK = 16 * 1024;        // 16KB 블록 단위
 static const size_t SAMPLE_REGION = 100 * 1024 * 1024; // 100MB 구간
@@ -32,7 +33,10 @@ bool is_compressed_format(const std::string& filepath)
     // 헤더 16바이트 읽기
     std::ifstream f(filepath, std::ios::binary);
     if (!f.is_open())
+    {
+        std::cerr << "format: failed to open file: " << filepath << "\n";
         return false;
+    }
 
     uint8_t header[HEADER_SIZE] = {};
     f.read(reinterpret_cast<char*>(header), HEADER_SIZE);
@@ -132,8 +136,10 @@ bool should_use_full_copy(const std::string& prev_path,
         };
 
         count_region(0);
-        count_region(mid_offset);
-        count_region(tail_offset);
+        if (mid_offset >= SAMPLE_REGION)
+            count_region(mid_offset);
+        if (tail_offset >= mid_offset + SAMPLE_REGION)
+            count_region(tail_offset);
     }
 
     if (total == 0)

--- a/src/engine/format.cpp
+++ b/src/engine/format.cpp
@@ -110,32 +110,37 @@ bool should_use_full_copy(const std::string& prev_path,
 
     uint64_t file_size = std::min(prev_size, curr_size);
 
-    // 샘플링 구간 3개: 앞 / 중간 / 뒤
-    uint64_t mid_offset  = (file_size / 2 > SAMPLE_REGION)
-                           ? file_size / 2 - SAMPLE_REGION / 2 : 0;
-    uint64_t tail_offset = (file_size > SAMPLE_REGION)
-                           ? file_size - SAMPLE_REGION : 0;
-
     size_t changed = 0;
     size_t total   = 0;
 
-    // 앞 구간
-    auto count_region = [&](uint64_t offset) {
-        uint64_t region = std::min(static_cast<uint64_t>(SAMPLE_REGION), file_size);
-        size_t blocks = (region + SAMPLE_BLOCK - 1) / SAMPLE_BLOCK;
-        changed += count_changed_blocks(prev_f, curr_f, offset, region);
+    // 파일이 300MB보다 작으면 전체를 한 번만 샘플링
+    if (file_size < SAMPLE_REGION * 3)
+    {
+        size_t blocks = (file_size + SAMPLE_BLOCK - 1) / SAMPLE_BLOCK;
+        changed += count_changed_blocks(prev_f, curr_f, 0, file_size);
         total   += blocks;
-    };
+    }
+    else
+    {
+        uint64_t mid_offset  = file_size / 2 - SAMPLE_REGION / 2;
+        uint64_t tail_offset = file_size - SAMPLE_REGION;
 
-    count_region(0);
-    count_region(mid_offset);
-    count_region(tail_offset);
+        auto count_region = [&](uint64_t offset) {
+            size_t blocks = (SAMPLE_REGION + SAMPLE_BLOCK - 1) / SAMPLE_BLOCK;
+            changed += count_changed_blocks(prev_f, curr_f, offset, SAMPLE_REGION);
+            total   += blocks;
+        };
+
+        count_region(0);
+        count_region(mid_offset);
+        count_region(tail_offset);
+    }
 
     if (total == 0)
         return false;
 
     double change_ratio = static_cast<double>(changed) /
-                          static_cast<double>(total);
+                        static_cast<double>(total);
 
     return change_ratio >= threshold;
 }

--- a/src/engine/format.h
+++ b/src/engine/format.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <string>
+
+/**
+ * is_compressed_format
+ * 파일 헤더(magic bytes)를 읽어 압축 포맷 여부를 판별한다.
+ *
+ * 압축 포맷(true): jpg, png, gif, zip, gzip, zstd, mp4
+ * 비압축 포맷(false): fbx, exr, tiff, obj 및 기타
+ *
+ * @param filepath 판별할 파일 경로
+ * @return         true면 전체 저장, false면 delta 추출
+ */
+bool is_compressed_format(const std::string& filepath);
+
+/**
+ * should_use_full_copy
+ * 두 파일을 샘플링해서 변경률이 높으면 전체 저장을 권장한다.
+ * 파일 앞/중간/뒤 각 100MB 구간에서 16KB 블록 단위로 변경 비율 추정.
+ *
+ * @param prev_path 직전 커밋 파일 경로
+ * @param curr_path 현재 파일 경로
+ * @param threshold 변경률 임계치 (기본값 0.8 = 80%)
+ * @return          true면 전체 저장, false면 delta 생성
+ */
+bool should_use_full_copy(const std::string& prev_path,
+                          const std::string& curr_path,
+                          double threshold = 0.8);

--- a/src/vcs/vcs.cpp
+++ b/src/vcs/vcs.cpp
@@ -11,6 +11,8 @@
 #include "json.hpp"
 #include "vcs.h"
 #include "../engine/delta.h"
+#include "../engine/format.h"
+
 
 namespace fs = std::filesystem;
 using json = nlohmann::json;
@@ -85,6 +87,56 @@ static void write_head(const fs::path &vcs_path, const std::string &commit_id)
     std::ofstream f(vcs_path / "HEAD");
     f << commit_id;
 }
+
+// 현재 커밋이 몇 번째인지 체인 길이로 계산
+static int count_commit_depth(const std::string& repo_path,
+                               const std::string& commit_id)
+{
+    int depth = 0;
+    std::string cur = commit_id;
+    while (!cur.empty())
+    {
+        CommitMetadata m = load_commit_metadata(repo_path, cur);
+        if (m.id.empty()) break;
+        ++depth;
+        if (!m.files.empty() && m.files[0].is_base) break;
+        cur = m.parent_id;
+    }
+    return depth;
+}
+
+// 스냅샷 저장
+static void save_snapshot(const fs::path& vcs_path,
+                           const std::string& commit_id,
+                           const std::string& target_file)
+{
+    fs::path snap_path = vcs_path / "objects" / "snapshots" /
+                         (commit_id + ".snap");
+    fs::copy_file(target_file, snap_path,
+                  fs::copy_options::overwrite_existing);
+}
+
+// 체인 역추적하며 가장 가까운 스냅샷 찾기
+// 반환값: 스냅샷 커밋 ID (없으면 빈 문자열)
+static std::string find_nearest_snapshot(const std::string& repo_path,
+                                          const fs::path& vcs_path,
+                                          const std::string& commit_id)
+{
+    std::string cur = commit_id;
+    while (!cur.empty())
+    {
+        fs::path snap = vcs_path / "objects" / "snapshots" / (cur + ".snap");
+        if (fs::exists(snap))
+            return cur;
+
+        CommitMetadata m = load_commit_metadata(repo_path, cur);
+        if (m.id.empty()) break;
+        if (!m.files.empty() && m.files[0].is_base) break;
+        cur = m.parent_id;
+    }
+    return "";
+}
+
 
 // 특정 커밋 시점의 파일 out_path에 복원
 static bool restore_file_at_commit(const std::string &repo_path,
@@ -382,56 +434,81 @@ std::string commit(const std::string &repo_path, const std::string &message, con
     }
     else
     {
-        // 직전 커밋 파일 기준으로 delta 생성
-        std::string delta_filename = commit_id + ".delta";
-        fs::path delta_path = vcs_path / "objects" / "deltas" / delta_filename;
-
-        fs::path prev_file;
-
-        /* parent_id가 비어 있는 경우:
-           base 파일은 이미 존재하지만(.vcs/objects/base/), 아직 커밋 JSON이 하나도 없는 상태
-           이 커밋이 "base 파일과 현재 작업본" 사이의 첫 번째 delta를 만드는 케이스
-           parent_id가 있는 분기로 들어가면 restore_file_at_commit()이 parent_id를 따라가다
-           JSON을 못 찾아 실패하므로, base 파일 자체를 비교 기준으로 사용한다.
-        */
-        if (parent_id.empty())
+        // 압축 포맷이면 delta 대신 전체 저장 (Git LFS 방식과 동일)
+        if (is_compressed_format(target_file))
         {
-            prev_file = base_file;
+            fs::copy_file(target_file, base_file,
+                      fs::copy_options::overwrite_existing);
+            uint64_t file_size = static_cast<uint64_t>(fs::file_size(target_file));
+            meta.files.push_back({target_file, "", true, file_sha256, file_size});
         }
         else
         {
-            // 직전 커밋 시점의 파일을 임시 경로에 복원
-            prev_file = vcs_path / ("prev_" + commit_id);
-            std::string filename = fs::path(target_file).filename().string();
+            // 직전 커밋 파일 기준으로 delta 생성
+            std::string delta_filename = commit_id + ".delta";
+            fs::path delta_path = vcs_path / "objects" / "deltas" / delta_filename;
 
-            if (!restore_file_at_commit(repo_path, parent_id, filename, prev_file))
+            fs::path prev_file;
+
+            /* parent_id가 비어 있는 경우:
+                base 파일은 이미 존재하지만(.vcs/objects/base/), 아직 커밋 JSON이 하나도 없는 상태
+                이 커밋이 "base 파일과 현재 작업본" 사이의 첫 번째 delta를 만드는 케이스
+                parent_id가 있는 분기로 들어가면 restore_file_at_commit()이 parent_id를 따라가다
+                JSON을 못 찾아 실패하므로, base 파일 자체를 비교 기준으로 사용한다.
+            */
+            if (parent_id.empty())
             {
-                std::cerr << "직전 커밋 파일 복원 실패\n";
-                return "";
+                prev_file = base_file;
+            }
+            else
+            {
+                // 직전 커밋 시점의 파일을 임시 경로에 복원
+                prev_file = vcs_path / ("prev_" + commit_id);
+                std::string filename = fs::path(target_file).filename().string();
+
+                if (!restore_file_at_commit(repo_path, parent_id, filename, prev_file))
+                {
+                    std::cerr << "직전 커밋 파일 복원 실패\n";
+                    return "";
+                }
+            }
+
+                    // 사전 샘플링 — 변경률 높으면 전체 저장으로 전환
+            if (should_use_full_copy(prev_file.string(), target_file))
+            {
+                if (!parent_id.empty() && fs::exists(prev_file))
+                    fs::remove(prev_file);
+
+                fs::copy_file(target_file, base_file,
+                              fs::copy_options::overwrite_existing);
+                uint64_t file_size = static_cast<uint64_t>(fs::file_size(target_file));
+                meta.files.push_back({target_file, "", true, file_sha256, file_size});
+            }
+            else
+            {
+                int ret = delta_create(prev_file.string().c_str(),
+                                        target_file.c_str(),
+                                        delta_path.string().c_str());
+
+                /* parent_id가 비어 있으면 위의 분기에서 prev_file = base_file 을 그대로
+                가리키고 있으므로, 임시 복원 파일이 생성된 적이 없다.즉, 삭제 대상이 없다.
+                parent_id가 있을 때만 restore_file_at_commit()이 임시 파일을 만들었으므로 해당 경우에만 정리한다.
+                */
+                if (!parent_id.empty() && fs::exists(prev_file))
+                    fs::remove(prev_file);
+
+                if (ret != 0)
+                {
+                    std::cerr << "delta 생성 실패\n";
+                    return "";
+                }
+
+                // delta 커밋
+                uint64_t file_size = static_cast<uint64_t>(fs::file_size(target_file));
+                meta.files.push_back(
+                    {target_file, "objects/deltas/" + delta_filename, false, file_sha256, file_size});
             }
         }
-
-        int ret = delta_create(prev_file.string().c_str(),
-                               target_file.c_str(),
-                               delta_path.string().c_str());
-
-        /* parent_id가 비어 있으면 위의 분기에서 prev_file = base_file 을 그대로
-         가리키고 있으므로, 임시 복원 파일이 생성된 적이 없다. 즉, 삭제 대상이 없다.
-         parent_id가 있을 때만 restore_file_at_commit()이 임시 파일을 만들었으므로 해당 경우에만 정리한다.
-        */
-        if (!parent_id.empty() && fs::exists(prev_file))
-            fs::remove(prev_file);
-
-        if (ret != 0)
-        {
-            std::cerr << "delta 생성 실패\n";
-            return "";
-        }
-
-        // delta 커밋
-        uint64_t file_size = static_cast<uint64_t>(fs::file_size(target_file));
-        meta.files.push_back(
-            {target_file, "objects/deltas/" + delta_filename, false, file_sha256, file_size});
     }
 
     // 5. JSON 저장 & HEAD 업데이트
@@ -439,6 +516,14 @@ std::string commit(const std::string &repo_path, const std::string &message, con
     {
         std::cerr << "커밋 메타데이터 저장 실패\n";
         return "";
+    }
+
+    // N커밋마다 스냅샷 저장
+    static const int SNAPSHOT_INTERVAL = 10;
+    int depth = count_commit_depth(repo_path, commit_id);
+    if (depth % SNAPSHOT_INTERVAL == 0)
+    {
+        save_snapshot(vcs_path, commit_id, target_file);
     }
 
     write_head(vcs_path, commit_id);
@@ -468,6 +553,7 @@ int checkout(const std::string &repo_path, const std::string &commit_id)
     // 2. base → 목표 커밋까지 delta 체인 구성 (parent_id 역추적)
     //    chain[0] = base 커밋, chain[back] = 목표 커밋
     std::vector<std::string> chain;
+    std::string snap_commit_id = find_nearest_snapshot(repo_path, vcs_path, commit_id);
     {
         std::string cur = commit_id;
         while (!cur.empty())
@@ -479,6 +565,9 @@ int checkout(const std::string &repo_path, const std::string &commit_id)
                 return -1;
             }
             chain.push_back(cur);
+
+            // 스냅샷 있으면 거기서 중단, 없으면 base까지
+            if (cur == snap_commit_id) break;
             // base 커밋(is_base == true)에 도달하면 중단
             if (!m.files.empty() && m.files[0].is_base)
                 break;
@@ -511,6 +600,14 @@ int checkout(const std::string &repo_path, const std::string &commit_id)
             // tmp_a: 현재 복원 중간 결과, tmp_b: delta 적용 후 출력
             fs::path tmp_a = vcs_path / ("tmp_a_" + commit_id);
             fs::path tmp_b = vcs_path / ("tmp_b_" + commit_id);
+
+
+            // 스냅샷 있으면 스냅샷에서 시작, 없으면 base에서 시작
+            fs::path start_file;
+            if (!snap_commit_id.empty())
+                start_file = vcs_path / "objects" / "snapshots" / (snap_commit_id + ".snap");
+            else
+                start_file = base_file;
 
             fs::copy_file(base_file, tmp_a,
                           fs::copy_options::overwrite_existing);


### PR DESCRIPTION
## 작업 내용
- format.h / format.cpp 추가
  - is_compressed_format(): 파일 헤더(magic bytes)로 압축 포맷 판별
    (jpg, png, gif, zip, gzip, zstd, mp4)
  - should_use_full_copy(): 파일 앞/중간/뒤 각 100MB 샘플링으로
    변경률 추정, 임계치(80%) 초과 시 전체 저장 권장

- vcs.cpp commit() 수정
  - 압축 포맷 → 전체 저장 분기 추가
  - 비압축 포맷 → 사전 샘플링 후 변경률 높으면 전체 저장, 낮으면 delta 생성
  - N=10 커밋마다 .vcs/objects/snapshots/ 에 스냅샷 저장

- vcs.cpp checkout() 수정
  - 체인 역추적 시 가장 가까운 스냅샷 탐색
  - 스냅샷 있으면 거기서부터 delta 적용 (복원 속도 향상)

- CMakeLists.txt
  - format.cpp 소스 추가

## 관련 Issue
Closes #27

## 변경된 파일
- src/engine/format.h
- src/engine/format.cpp
- src/vcs/vcs.cpp
- CMakeLists.txt

## 체크리스트
- [x] 본인 브랜치에서 작업했다 (feat/engine-format-detect)
- [x] 커밋 메시지 규칙을 따랐다 (feat: / build:)
- [x] 팀원 1명을 Reviewer로 지정했다
- [x] 코드에 주석을 달았다

## 리뷰어에게
is_compressed_format()과 should_use_full_copy() 로직 위주로 봐주세요.
샘플링 임계치(80%)와 스냅샷 주기(N=10)는 벤치마크 후 조정 예정입니다.