### PR TITLE
feat: dgit add 폴더 입력 시 바이너리 확장자 전체 수집

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 
 #include "../vcs/vcs.h"
+#include "../engine/format.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -259,6 +260,13 @@ namespace {
         return fs::is_regular_file(path) && has_fbx_extension(path);
     }
 
+    // 실제 일반 파일이며 지원 바이너리 확장자인지 확인함.
+    bool is_binary_file(const fs::path& path) {
+        if (!fs::is_regular_file(path)) return false;
+        const std::string ext = to_lower(path.extension().string());
+        return BINARY_EXTENSIONS.count(ext) > 0;
+    }
+
     // 단일 파일을 명시적으로 add/commit할 때 .fbx만 허용할지 빌드 옵션에 따라 결정함.
     bool explicit_file_allowed_by_policy(const fs::path& path) {
 #if DGIT_STRICT_FBX_ONLY
@@ -475,7 +483,7 @@ namespace {
                         continue;
                     }
 
-                    if (!is_fbx_file(entry_path)) {
+                    if (!is_binary_file(entry_path)) {
                         continue;
                     }
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -29,7 +29,7 @@ namespace fs = std::filesystem;
  *
  * 주요 설계 포인트:
  *  - 서브폴더에서 dgit을 실행해도 저장소 루트(.vcs가 있는 폴더)를 찾아 동작함.
- *  - add 폴더 입력 시 .fbx 파일만 재귀적으로 수집함.
+ *  - add 폴더 입력 시 .바이너리 파일을 재귀적으로 수집함
  *  - commit은 디스크 전체를 훑지 않고 .vcs/index에 등록된 추적 파일만 대상으로 함.
  *  - VCS가 다중 파일 atomic commit을 지원하지 않으면 여러 커밋으로 쪼개지 않고 안전하게 실패 처리함.
  */
@@ -346,7 +346,7 @@ namespace {
         }
         else if (command == "add") {
             std::cout << u8"사용법: dgit add <file|folder>\n\n"
-                << u8"파일 하나를 추적 목록에 추가합니다. 폴더를 입력하면 내부의 .fbx 파일만 추가합니다.\n"
+                << u8"파일 하나를 추적 목록에 추가합니다. 폴더를 입력하면 내부의 바이너리 파일만 추가합니다.\n"
 #if DGIT_STRICT_FBX_ONLY
                 << u8"이 빌드는 명시적으로 추가한 파일도 .fbx만 허용합니다.\n"
 #else
@@ -790,7 +790,7 @@ namespace {
         }
 
         if (targets.empty()) {
-            std::cout << u8".fbx 파일을 찾지 못했습니다: " << args[2] << "\n";
+            std::cout << u8".바이너리 파일을 찾지 못했습니다: " << args[2] << "\n";
             return 0;
         }
 

--- a/src/engine/format.h
+++ b/src/engine/format.h
@@ -1,5 +1,22 @@
 #pragma once
 #include <string>
+#include <unordered_set>
+#include <string>
+
+
+// 폴더 add 시 수집 대상 바이너리 확장자 목록
+static const std::unordered_set<std::string> BINARY_EXTENSIONS = {
+    // 3D 메시/씬
+    ".fbx", ".obj", ".dae", ".3ds", ".blend", ".abc",
+    // 텍스처/이미지 (비압축)
+    ".exr", ".tiff", ".tif", ".tga", ".hdr", ".psd",
+    // 텍스처/이미지 (압축 → commit 시 fullcopy 분기)
+    ".png", ".jpg", ".jpeg", ".bmp",
+    // 동영상/오디오
+    ".mp4", ".mov", ".wav",
+    // 기타 바이너리
+    ".bin", ".raw", ".vdb"
+};
 
 /**
  * is_compressed_format

--- a/src/engine/format.h
+++ b/src/engine/format.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <string>
 #include <unordered_set>
-#include <string>
 
 
 // 폴더 add 시 수집 대상 바이너리 확장자 목록


### PR DESCRIPTION
## 작업 내용
- format.h에 BINARY_EXTENSIONS 상수 추가
  .fbx .obj .dae .3ds .blend .abc
  .exr .tiff .tif .tga .hdr .psd
  .png .jpg .jpeg .bmp
  .mp4 .mov .wav
  .bin .raw .vdb

- main.cpp 폴더 add 로직에서
  is_fbx_file() → is_binary_file()로 교체
  벤치마크 실험 시 다양한 포맷 일괄 add 가능

## 관련 Issue
Closes #39 

## 변경된 파일
- src/engine/format.h
- src/cli/main.cpp
- 
## 체크리스트
- [x] 본인 브랜치에서 작업했다 (feat/cli-folder-add)
- [x] 커밋 메시지 규칙을 따랐다
- [x] 팀원 1명을 Reviewer로 지정했다
- [x] 코드에 주석을 달았다

## 리뷰어에게
벤치마크 실험 준비용으로 폴더 add 확장자를
.fbx 단일에서 바이너리 포맷 전체로 확장했습니다.
기존 단일 파일 add 동작은 변경 없습니다!