### PR TITLE
feat: 벤치마크 자동화 스크립트 및 성능 최적화

### DIFF
--- a/benchmark/measure.py
+++ b/benchmark/measure.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""
+designer_git benchmark measurement script
+Runs all scenarios and saves results to CSV.
+
+Usage:
+    python3 measure.py --dgit /path/to/dgit --output results/
+"""
+
+import os
+import sys
+import csv
+import time
+import shutil
+import random
+import argparse
+import subprocess
+from pathlib import Path
+
+# ── 설정 ─────────────────────────────────────────────────────
+REPEAT = 3          # 반복 횟수
+RESULTS_DIR = Path("results")
+REPO_DIR = Path("_bench_repo")  # 임시 저장소
+
+# ── 유틸 ─────────────────────────────────────────────────────
+
+def drop_os_caches():
+    """OS 페이지 캐시 플러시 — 캐시 효과로 인한 측정값 왜곡 방지"""
+    try:
+        subprocess.run("sync && echo 3 > /proc/sys/vm/drop_caches",
+                       shell=True, check=False)
+    except Exception:
+        pass  # 권한 없으면 무시 (sudo 없이 실행 시)
+
+
+def run(cmd, cwd=None):
+    """명령어 실행 전 OS 캐시 플러시 후 시간 측정"""
+    drop_os_caches()
+    start = time.perf_counter()
+    result = subprocess.run(
+        cmd, shell=True, cwd=cwd,
+        capture_output=True, text=True
+    )
+    elapsed = time.perf_counter() - start
+    return result.returncode, result.stdout, result.stderr, elapsed
+
+
+def repo_size_kb(path):
+    """디렉터리 전체 크기 KB 반환"""
+    total = 0
+    for f in Path(path).rglob("*"):
+        if f.is_file():
+            total += f.stat().st_size
+    return total / 1024
+
+
+def delta_size_kb(repo_path):
+    """.vcs/objects/deltas/ 크기 KB 반환"""
+    deltas = Path(repo_path) / ".vcs" / "objects" / "deltas"
+    if not deltas.exists():
+        return 0
+    total = sum(f.stat().st_size for f in deltas.rglob("*") if f.is_file())
+    return total / 1024
+
+
+def vcs_size_kb(repo_path):
+    """.vcs/ 전체 크기 KB 반환"""
+    vcs = Path(repo_path) / ".vcs"
+    if not vcs.exists():
+        return 0
+    total = sum(f.stat().st_size for f in vcs.rglob("*") if f.is_file())
+    return total / 1024
+
+
+def setup_repo(dgit, repo_path):
+    """임시 저장소 초기화"""
+    if repo_path.exists():
+        shutil.rmtree(repo_path)
+    repo_path.mkdir(parents=True)
+    run(f"{dgit} init", cwd=repo_path)
+
+
+def teardown_repo(repo_path):
+    """임시 저장소 삭제"""
+    if repo_path.exists():
+        shutil.rmtree(repo_path)
+
+
+def save_csv(filename, rows, fieldnames):
+    """CSV 저장"""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    filepath = RESULTS_DIR / filename
+    with open(filepath, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"  saved: {filepath}")
+
+
+# ── 파일 생성 함수 ────────────────────────────────────────────
+
+def make_random_file(path, size_mb):
+    """난수 바이너리 파일 생성"""
+    path = Path(path)
+    with open(path, "wb") as f:
+        for _ in range(size_mb):
+            f.write(os.urandom(1024 * 1024))
+
+
+def make_exr(path, size_mb):
+    """exr magic 헤더 + 난수 데이터"""
+    path = Path(path)
+    header = bytes([0x76, 0x2F, 0x31, 0x01])
+    with open(path, "wb") as f:
+        f.write(header)
+        remaining = size_mb * 1024 * 1024 - len(header)
+        for _ in range(remaining // (1024 * 1024)):
+            f.write(os.urandom(1024 * 1024))
+        f.write(os.urandom(remaining % (1024 * 1024)))
+
+
+def make_tiff(path, size_mb):
+    """tiff magic 헤더 + 난수 데이터"""
+    path = Path(path)
+    header = bytes([0x49, 0x49, 0x2A, 0x00])
+    with open(path, "wb") as f:
+        f.write(header)
+        remaining = size_mb * 1024 * 1024 - len(header)
+        for _ in range(remaining // (1024 * 1024)):
+            f.write(os.urandom(1024 * 1024))
+        f.write(os.urandom(remaining % (1024 * 1024)))
+
+
+def make_jpg(path, size_mb):
+    """jpg magic 헤더 + 난수 데이터"""
+    path = Path(path)
+    header = bytes([0xFF, 0xD8, 0xFF, 0xE0])
+    with open(path, "wb") as f:
+        f.write(header)
+        remaining = size_mb * 1024 * 1024 - len(header)
+        f.write(os.urandom(remaining))
+
+
+def make_png(path, size_mb):
+    """png magic 헤더 + 난수 데이터"""
+    path = Path(path)
+    header = bytes([0x89, 0x50, 0x4E, 0x47,
+                    0x0D, 0x0A, 0x1A, 0x0A])
+    with open(path, "wb") as f:
+        f.write(header)
+        remaining = size_mb * 1024 * 1024 - len(header)
+        f.write(os.urandom(remaining))
+
+
+def make_abc(path, size_mb):
+    """abc (Alembic) 난수 파일"""
+    make_random_file(path, size_mb)
+
+
+# ── 수정 함수 ─────────────────────────────────────────────────
+
+def modify_1byte(src, dst):
+    """중간 지점 1바이트 수정"""
+    shutil.copy2(src, dst)
+    size = os.path.getsize(dst)
+    with open(dst, "r+b") as f:
+        f.seek(size // 2)
+        f.write(b"\x42")
+
+
+def modify_percent(src, dst, percent):
+    """파일의 percent% 구간 난수로 덮어쓰기 (In-place)"""
+    shutil.copy2(src, dst)
+    size = os.path.getsize(dst)
+    modify_size = max(1, int(size * percent / 100))
+    offset = random.randint(0, size - modify_size)
+    with open(dst, "r+b") as f:
+        f.seek(offset)
+        f.write(os.urandom(modify_size))
+
+
+def modify_insert(src, dst, insert_kb=1):
+    """중간 지점에 데이터 삽입 (Insert — 뒤쪽 밀림)"""
+    with open(src, "rb") as f:
+        data = bytearray(f.read())
+    insert_pos = len(data) // 2
+    dummy = bytearray(os.urandom(insert_kb * 1024))
+    data[insert_pos:insert_pos] = dummy
+    with open(dst, "wb") as f:
+        f.write(data)
+
+
+def modify_full(src, dst):
+    """전체 교체"""
+    size = os.path.getsize(src)
+    with open(dst, "wb") as f:
+        f.write(os.urandom(size))
+
+
+# ── 시나리오 함수 ─────────────────────────────────────────────
+
+def scenario_1(dgit):
+    """
+    시나리오 1: Rolling Hash 당위성 — abc Insert 수정
+    abc 파일 중간에 1KB 삽입 → delta 크기 측정
+    """
+    print("\n[Scenario 1] Rolling Hash — abc Insert")
+    rows = []
+    repo = REPO_DIR / "s1"
+
+    for run_no in range(1, REPEAT + 1):
+        for size_mb in [100]:
+            setup_repo(dgit, repo)
+            src = repo / "simulation.abc"
+            dst = repo / "simulation_v2.abc"
+
+            print(f"  run={run_no} size={size_mb}MB ... ", end="", flush=True)
+            make_abc(src, size_mb)
+
+            # 최초 커밋
+            run(f"{dgit} add simulation.abc", cwd=repo)
+            _, _, _, commit_t1 = run(
+                f"{dgit} commit -m init simulation.abc", cwd=repo)
+
+            # Insert 수정
+            modify_insert(src, dst, insert_kb=1)
+            shutil.move(str(dst), str(src))
+
+            # 두 번째 커밋
+            _, _, _, commit_t2 = run(
+                f"{dgit} commit -m modify simulation.abc", cwd=repo)
+
+            d_kb = delta_size_kb(repo)
+            v_kb = vcs_size_kb(repo)
+            savings = (1 - d_kb / (size_mb * 1024)) * 100
+
+            print(f"delta={d_kb:.1f}KB savings={savings:.2f}%")
+            rows.append({
+                "scenario": 1,
+                "run": run_no,
+                "file_type": "abc",
+                "size_mb": size_mb,
+                "modify_type": "insert_1KB",
+                "commit_time_s": round(commit_t2, 3),
+                "delta_kb": round(d_kb, 2),
+                "vcs_kb": round(v_kb, 2),
+                "savings_pct": round(savings, 2),
+            })
+            teardown_repo(repo)
+
+    save_csv("scenario_1.csv", rows, list(rows[0].keys()))
+
+
+def scenario_2(dgit):
+    """
+    시나리오 2: 스토리지 절감 핵심 — exr 1GB × 5회 반복 커밋
+    """
+    print("\n[Scenario 2] Storage comparison — exr 1GB x5 commits")
+    rows = []
+    repo = REPO_DIR / "s2"
+
+    for run_no in range(1, REPEAT + 1):
+        setup_repo(dgit, repo)
+        src = repo / "texture.exr"
+        print(f"  run={run_no} generating 1GB exr ... ", end="", flush=True)
+        make_exr(src, 1024)
+        run(f"{dgit} add texture.exr", cwd=repo)
+
+        for commit_no in range(1, 6):
+            tmp = repo / "texture_mod.exr"
+            modify_percent(src, tmp, 1)
+            shutil.move(str(tmp), str(src))
+            _, _, _, commit_t = run(
+                f"{dgit} commit -m v{commit_no} texture.exr", cwd=repo)
+            v_kb = vcs_size_kb(repo)
+            d_kb = delta_size_kb(repo)
+            print(f"commit{commit_no} vcs={v_kb/1024:.2f}GB ", end="", flush=True)
+            rows.append({
+                "scenario": 2,
+                "run": run_no,
+                "file_type": "exr",
+                "size_mb": 1024,
+                "commit_no": commit_no,
+                "modify_type": "1pct",
+                "commit_time_s": round(commit_t, 3),
+                "delta_kb": round(d_kb, 2),
+                "vcs_total_kb": round(v_kb, 2),
+            })
+        print()
+        teardown_repo(repo)
+
+    save_csv("scenario_2.csv", rows, list(rows[0].keys()))
+
+
+def scenario_3(dgit):
+    """
+    시나리오 3: 텍스처 In-place 수정 — exr, tiff
+    """
+    print("\n[Scenario 3] Texture In-place — exr, tiff")
+    rows = []
+    repo = REPO_DIR / "s3"
+    makers = [("exr", make_exr), ("tiff", make_tiff)]
+
+    for run_no in range(1, REPEAT + 1):
+        for size_mb in [100, 1024]:
+            for ext, maker in makers:
+                setup_repo(dgit, repo)
+                src = repo / f"texture.{ext}"
+                print(f"  run={run_no} {ext} {size_mb}MB ... ",
+                      end="", flush=True)
+                maker(src, size_mb)
+                run(f"{dgit} add texture.{ext}", cwd=repo)
+                run(f"{dgit} commit -m init texture.{ext}", cwd=repo)
+
+                tmp = repo / f"texture_mod.{ext}"
+                modify_percent(src, tmp, 0.01)
+                shutil.move(str(tmp), str(src))
+                _, _, _, commit_t = run(
+                    f"{dgit} commit -m modify texture.{ext}", cwd=repo)
+
+                d_kb = delta_size_kb(repo)
+                savings = (1 - d_kb / (size_mb * 1024)) * 100
+                print(f"delta={d_kb:.1f}KB savings={savings:.2f}%")
+
+                rows.append({
+                    "scenario": 3,
+                    "run": run_no,
+                    "file_type": ext,
+                    "size_mb": size_mb,
+                    "modify_type": "inplace_0.01pct",
+                    "commit_time_s": round(commit_t, 3),
+                    "delta_kb": round(d_kb, 2),
+                    "savings_pct": round(savings, 2),
+                })
+                teardown_repo(repo)
+
+    save_csv("scenario_3.csv", rows, list(rows[0].keys()))
+
+
+def scenario_6(dgit):
+    """
+    시나리오 6: Early-exit 판단 시간 측정
+    80%+ 변경 파일에서 should_use_full_copy() 소요 시간
+    """
+    print("\n[Scenario 6] Early-exit timing")
+    rows = []
+    repo = REPO_DIR / "s6"
+
+    for run_no in range(1, REPEAT + 1):
+        for size_mb in [100, 1024]:
+            setup_repo(dgit, repo)
+            src = repo / "model.fbx"
+            print(f"  run={run_no} fbx {size_mb}MB ... ", end="", flush=True)
+            make_random_file(src, size_mb)
+            run(f"{dgit} add model.fbx", cwd=repo)
+            run(f"{dgit} commit -m init model.fbx", cwd=repo)
+
+            # 85% 변경 → Early-exit 트리거
+            tmp = repo / "model_mod.fbx"
+            modify_percent(src, tmp, 85)
+            shutil.move(str(tmp), str(src))
+            _, _, _, commit_t = run(
+                f"{dgit} commit -m modify model.fbx", cwd=repo)
+
+            d_kb = delta_size_kb(repo)
+            print(f"commit_time={commit_t:.3f}s delta={d_kb:.1f}KB")
+
+            rows.append({
+                "scenario": 6,
+                "run": run_no,
+                "file_type": "fbx",
+                "size_mb": size_mb,
+                "modify_type": "85pct_earlyexit",
+                "commit_time_s": round(commit_t, 3),
+                "delta_kb": round(d_kb, 2),
+            })
+            teardown_repo(repo)
+
+    save_csv("scenario_6.csv", rows, list(rows[0].keys()))
+
+
+def scenario_7(dgit):
+    """
+    시나리오 7: 압축 포맷 fallback — jpg, png
+    delta 파일이 생성되지 않아야 함
+    """
+    print("\n[Scenario 7] Compressed format fallback — jpg, png")
+    rows = []
+    repo = REPO_DIR / "s7"
+    makers = [("jpg", make_jpg), ("png", make_png)]
+
+    for run_no in range(1, REPEAT + 1):
+        for ext, maker in makers:
+            setup_repo(dgit, repo)
+            src = repo / f"texture.{ext}"
+            print(f"  run={run_no} {ext} 100MB ... ", end="", flush=True)
+            maker(src, 100)
+            run(f"{dgit} add texture.{ext}", cwd=repo)
+            run(f"{dgit} commit -m init texture.{ext}", cwd=repo)
+
+            tmp = repo / f"texture_mod.{ext}"
+            modify_1byte(src, tmp)
+            shutil.move(str(tmp), str(src))
+            _, _, _, commit_t = run(
+                f"{dgit} commit -m modify texture.{ext}", cwd=repo)
+
+            d_kb = delta_size_kb(repo)
+            v_kb = vcs_size_kb(repo)
+            fullcopy = d_kb == 0  # delta 없으면 fullcopy
+
+            print(f"delta={d_kb:.1f}KB fullcopy={fullcopy}")
+
+            rows.append({
+                "scenario": 7,
+                "run": run_no,
+                "file_type": ext,
+                "size_mb": 100,
+                "modify_type": "1byte",
+                "commit_time_s": round(commit_t, 3),
+                "delta_kb": round(d_kb, 2),
+                "vcs_kb": round(v_kb, 2),
+                "fullcopy": fullcopy,
+            })
+            teardown_repo(repo)
+
+    save_csv("scenario_7.csv", rows, list(rows[0].keys()))
+
+
+def scenario_8(dgit):
+    """
+    시나리오 8: 1바이트 수정 이론치 검증
+    """
+    print("\n[Scenario 8] 1-byte modify — theory max efficiency")
+    rows = []
+    repo = REPO_DIR / "s8"
+    makers = [("exr", make_exr)]
+
+    for run_no in range(1, REPEAT + 1):
+        for size_mb in [100, 1024]:
+            for ext, maker in makers:
+                setup_repo(dgit, repo)
+                src = repo / f"file.{ext}"
+                print(f"  run={run_no} {ext} {size_mb}MB ... ",
+                      end="", flush=True)
+                maker(src, size_mb)
+                run(f"{dgit} add file.{ext}", cwd=repo)
+                run(f"{dgit} commit -m init file.{ext}", cwd=repo)
+
+                tmp = repo / f"file_mod.{ext}"
+                modify_1byte(src, tmp)
+                shutil.move(str(tmp), str(src))
+                rc, stdout, stderr, commit_t = run(
+                    f"{dgit} commit -m modify file.{ext}", cwd=repo)
+                print(f"  rc={rc} stdout={stdout.strip()} stderr={stderr.strip()}")
+
+                d_kb = delta_size_kb(repo)
+                savings = (1 - d_kb / (size_mb * 1024)) * 100
+
+                # checkout 시간 측정
+                head_path = repo / ".vcs" / "HEAD"
+                if not head_path.exists():
+                    print("HEAD not found, skipping checkout")
+                    checkout_t = 0.0
+                else:
+                    head = head_path.read_text().strip()
+                    _, _, _, checkout_t = run(
+                        f"{dgit} checkout {head}", cwd=repo)
+
+                print(f"delta={d_kb:.1f}KB savings={savings:.2f}% "
+                      f"checkout={checkout_t:.3f}s")
+
+                rows.append({
+                    "scenario": 8,
+                    "run": run_no,
+                    "file_type": ext,
+                    "size_mb": size_mb,
+                    "modify_type": "1byte",
+                    "commit_time_s": round(commit_t, 3),
+                    "checkout_time_s": round(checkout_t, 3),
+                    "delta_kb": round(d_kb, 2),
+                    "savings_pct": round(savings, 2),
+                })
+                teardown_repo(repo)
+
+    save_csv("scenario_8.csv", rows, list(rows[0].keys()))
+
+
+# ── main ──────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="designer_git benchmark")
+    parser.add_argument("--dgit", required=True,
+                        help="Path to dgit executable")
+    parser.add_argument("--scenarios", default="1,2,3,6,7,8",
+                        help="Comma-separated scenario numbers to run")
+    args = parser.parse_args()
+
+    dgit = str(Path(args.dgit).resolve())
+    scenarios = [int(s) for s in args.scenarios.split(",")]
+
+    print(f"dgit: {dgit}")
+    print(f"scenarios: {scenarios}")
+    print(f"repeat: {REPEAT}")
+
+    scenario_map = {
+        1: scenario_1,
+        2: scenario_2,
+        3: scenario_3,
+        6: scenario_6,
+        7: scenario_7,
+        8: scenario_8,
+    }
+
+    for s in scenarios:
+        if s in scenario_map:
+            scenario_map[s](dgit)
+        else:
+            print(f"[SKIP] scenario {s} not implemented yet")
+
+    print("\nAll done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/plot.py
+++ b/benchmark/plot.py
@@ -73,10 +73,6 @@ def plot_scenario2_storage(results_dir, output_dir):
 
     # commit_no별 vcs_total_kb 평균
     commits = sorted(set(int(r["commit_no"]) for r in rows))
-    dgit_sizes = []
-    for c in commits:
-        vals = [r["vcs_total_kb"] for r in rows if int(r["commit_no"]) == c]
-        dgit_sizes.append(avg(vals) / 1024 / 1024)  # KB → TB? No, KB→GB
 
     # Git LFS: 1GB 파일 × commit 횟수 (전체 재저장)
     lfs_sizes = [c * 1024 for c in commits]  # MB

--- a/benchmark/plot.py
+++ b/benchmark/plot.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""
+designer_git benchmark plot script
+Reads CSV results and generates graphs.
+
+Usage:
+    python3 plot.py --results results/ --output graphs/
+"""
+
+import os
+import csv
+import argparse
+from pathlib import Path
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import matplotlib.ticker as ticker
+except ImportError:
+    print("matplotlib not found. Install: pip install matplotlib")
+    exit(1)
+
+# ── 설정 ─────────────────────────────────────────────────────
+COLORS = {
+    "designer_git": "#2563eb",
+    "git_lfs":      "#dc2626",
+    "fixed_chunk":  "#f59e0b",
+    "rolling_hash": "#2563eb",
+}
+
+plt.rcParams.update({
+    "font.size": 11,
+    "axes.titlesize": 13,
+    "axes.labelsize": 11,
+    "figure.dpi": 150,
+})
+
+
+def load_csv(path):
+    rows = []
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def avg(values):
+    vals = [float(v) for v in values if v != ""]
+    return sum(vals) / len(vals) if vals else 0
+
+
+def save(fig, output_dir, filename):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / filename
+    fig.savefig(path, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  saved: {path}")
+
+
+# ── 그래프 1: 시나리오 2 누적 저장소 크기 ─────────────────────
+
+def plot_scenario2_storage(results_dir, output_dir):
+    """Git LFS vs designer-git 누적 저장소 크기 비교"""
+    path = Path(results_dir) / "scenario_2.csv"
+    if not path.exists():
+        print(f"[SKIP] {path} not found")
+        return
+
+    rows = load_csv(path)
+
+    # commit_no별 vcs_total_kb 평균
+    commits = sorted(set(int(r["commit_no"]) for r in rows))
+    dgit_sizes = []
+    for c in commits:
+        vals = [r["vcs_total_kb"] for r in rows if int(r["commit_no"]) == c]
+        dgit_sizes.append(avg(vals) / 1024 / 1024)  # KB → TB? No, KB→GB
+
+    # Git LFS: 1GB 파일 × commit 횟수 (전체 재저장)
+    lfs_sizes = [c * 1024 for c in commits]  # MB
+    lfs_sizes_gb = [s / 1024 for s in lfs_sizes]  # GB
+    dgit_sizes_gb = [avg([r["vcs_total_kb"]
+                         for r in rows if int(r["commit_no"]) == c]) / 1024 / 1024
+                     for c in commits]
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.plot(commits, lfs_sizes_gb,
+            marker="o", color=COLORS["git_lfs"],
+            linewidth=2, label="Git LFS")
+    ax.plot(commits, dgit_sizes_gb,
+            marker="s", color=COLORS["designer_git"],
+            linewidth=2, label="designer-git")
+
+    ax.set_xlabel("Commit count")
+    ax.set_yscale('log')
+    ax.set_ylabel("Cumulative storage (GB, Log Scale)")
+    ax.set_title("Git LFS vs designer-git\nCumulative storage (1GB exr, 1% modify per commit)")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    ax.set_xticks(commits)
+
+    save(fig, output_dir, "scenario2_storage.png")
+
+
+# ── 그래프 2: 시나리오 1 Rolling Hash 당위성 ─────────────────
+
+def plot_scenario1_rolling_hash(results_dir, output_dir):
+    """Rolling Hash vs 고정 청크 delta 크기 비교"""
+    path = Path(results_dir) / "scenario_1.csv"
+    if not path.exists():
+        print(f"[SKIP] {path} not found")
+        return
+
+    rows = load_csv(path)
+
+    # Rolling Hash: 실측 delta 크기
+    rh_delta = avg([r["delta_kb"] for r in rows])
+
+    # 고정 청크 추정: Insert 1KB → 절반 이후 전부 INSERT
+    # 100MB 파일, 16KB 청크 기준 → 절반인 50MB = 3200 청크 INSERT
+    estimated_fixed = 50 * 1024  # 약 50MB in KB
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    bars = ax.bar(
+        ["Fixed Chunk\n(estimated)", "Rolling Hash\n(actual)"],
+        [estimated_fixed, rh_delta],
+        color=[COLORS["fixed_chunk"], COLORS["rolling_hash"]],
+        width=0.5
+    )
+
+    for bar, val in zip(bars, [estimated_fixed, rh_delta]):
+        ax.text(bar.get_x() + bar.get_width() / 2,
+                bar.get_height() + 200,
+                f"{val/1024:.1f} MB",
+                ha="center", fontsize=11)
+
+    ax.set_ylabel("Delta size (KB)")
+    ax.set_title("Rolling Hash vs Fixed Chunk\nDelta size after 1KB Insert (100MB abc)")
+    ax.grid(True, alpha=0.3, axis="y")
+
+    save(fig, output_dir, "scenario1_rolling_hash.png")
+
+
+# ── 그래프 3: 시나리오 3 텍스처 In-place 효율 ────────────────
+
+def plot_scenario3_texture(results_dir, output_dir):
+    """exr vs tiff In-place 수정 절감률"""
+    path = Path(results_dir) / "scenario_3.csv"
+    if not path.exists():
+        print(f"[SKIP] {path} not found")
+        return
+
+    rows = load_csv(path)
+    file_types = sorted(set(r["file_type"] for r in rows))
+    sizes = sorted(set(int(r["size_mb"]) for r in rows))
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    x = list(range(len(sizes)))
+    width = 0.35
+
+    for i, ft in enumerate(file_types):
+        savings = []
+        for sz in sizes:
+            vals = [r["savings_pct"]
+                    for r in rows
+                    if r["file_type"] == ft and int(r["size_mb"]) == sz]
+            savings.append(avg(vals))
+        offset = (i - len(file_types) / 2 + 0.5) * width
+        ax.bar([xi + offset for xi in x], savings,
+               width=width, label=f".{ft}")
+
+    ax.set_xlabel("File size")
+    ax.set_ylabel("Storage savings (%)")
+    ax.set_title("Texture In-place Modify\nStorage savings by file type and size")
+    ax.set_xticks(x)
+    ax.set_xticklabels([f"{s}MB" if s < 1024 else f"{s//1024}GB" for s in sizes])
+    ax.set_ylim(0, 105)
+    ax.legend()
+    ax.grid(True, alpha=0.3, axis="y")
+
+    save(fig, output_dir, "scenario3_texture.png")
+
+
+# ── 그래프 4: 시나리오 7 압축 포맷 fallback ──────────────────
+
+def plot_scenario7_fallback(results_dir, output_dir):
+    """jpg vs png fullcopy 분기 확인"""
+    path = Path(results_dir) / "scenario_7.csv"
+    if not path.exists():
+        print(f"[SKIP] {path} not found")
+        return
+
+    rows = load_csv(path)
+    file_types = sorted(set(r["file_type"] for r in rows))
+
+    vcs_sizes = []
+    for ft in file_types:
+        vals = [float(r["vcs_kb"]) for r in rows if r["file_type"] == ft]
+        vcs_sizes.append(avg(vals) / 1024)  # KB → MB
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    bars = ax.bar(file_types, vcs_sizes,
+                  color=[COLORS["git_lfs"]] * len(file_types),
+                  width=0.4)
+
+    for bar, val in zip(bars, vcs_sizes):
+        ax.text(bar.get_x() + bar.get_width() / 2,
+                bar.get_height() + 0.5,
+                f"{val:.1f} MB\n(fullcopy)",
+                ha="center", fontsize=10)
+
+    ax.set_ylabel("Storage size after 2nd commit (MB)")
+    ax.set_title("Compressed Format Fallback\njpg / png → fullcopy (no delta)")
+    ax.grid(True, alpha=0.3, axis="y")
+
+    save(fig, output_dir, "scenario7_fallback.png")
+
+
+# ── 그래프 5: 시나리오 8 이론치 ──────────────────────────────
+
+def plot_scenario8_theory(results_dir, output_dir):
+    """1바이트 수정 delta 크기"""
+    path = Path(results_dir) / "scenario_8.csv"
+    if not path.exists():
+        print(f"[SKIP] {path} not found")
+        return
+
+    rows = load_csv(path)
+    sizes = sorted(set(int(r["size_mb"]) for r in rows))
+
+    delta_kbs = []
+    savings = []
+    for sz in sizes:
+        vals_d = [float(r["delta_kb"]) for r in rows if int(r["size_mb"]) == sz]
+        vals_s = [float(r["savings_pct"]) for r in rows if int(r["size_mb"]) == sz]
+        delta_kbs.append(avg(vals_d))
+        savings.append(avg(vals_s))
+
+    fig, ax1 = plt.subplots(figsize=(7, 5))
+    ax2 = ax1.twinx()
+
+    x = list(range(len(sizes)))
+    ax1.bar(x, delta_kbs, color=COLORS["designer_git"],
+            alpha=0.7, width=0.4, label="Delta size (KB)")
+    ax2.plot(x, savings, marker="o", color=COLORS["git_lfs"],
+             linewidth=2, label="Savings (%)")
+
+    ax1.set_xlabel("File size")
+    ax1.set_ylabel("Delta size (KB)", color=COLORS["designer_git"])
+    ax2.set_ylabel("Storage savings (%)", color=COLORS["git_lfs"])
+    ax1.set_xticks(x)
+    ax1.set_xticklabels([f"{s}MB" if s < 1024 else f"{s//1024}GB" for s in sizes])
+    ax1.set_title("1-byte Modify: Delta size & Savings\n(Theory max efficiency)")
+
+    lines1, labels1 = ax1.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax1.legend(lines1 + lines2, labels1 + labels2, loc="center right")
+    ax1.grid(True, alpha=0.3, axis="y")
+
+    save(fig, output_dir, "scenario8_theory.png")
+
+
+# ── 그래프 6: 파이프라인 단계별 적용 가능성 표 ───────────────
+
+def plot_pipeline_table(output_dir):
+    """파이프라인 단계별 적용 가능성 요약 표"""
+    stages = [
+        ("Initial Modeling",   "Sculpting, polygon edit",        "❌ Low",  "#fee2e2"),
+        ("Texturing",          "Pixel color/material modify",     "✅ High", "#dcfce7"),
+        ("Rigging",            "Bone structure addition",         "✅ High", "#dcfce7"),
+        ("Animation",          "Keyframe value modify",           "✅ High", "#dcfce7"),
+        ("Scene Assembly",     "Object placement/transform",      "✅ High", "#dcfce7"),
+        ("VFX Cache",          "Alembic frame insertion",         "✅ High", "#dcfce7"),
+    ]
+
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.axis("off")
+
+    headers = ["Pipeline Stage", "Work Pattern", "Delta Efficiency"]
+    data = [[s[0], s[1], s[2]] for s in stages]
+    colors = [["#f1f5f9", "#f1f5f9", "#f1f5f9"]] + \
+             [[s[3], s[3], s[3]] for s in stages]
+
+    table = ax.table(
+        cellText=[headers] + data,
+        cellLoc="center",
+        loc="center",
+        cellColours=colors
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(11)
+    table.scale(1, 2)
+
+    # 헤더 스타일
+    for j in range(3):
+        table[0, j].set_facecolor("#1e293b")
+        table[0, j].set_text_props(color="white", fontweight="bold")
+
+    ax.set_title("Pipeline Stage vs Delta Efficiency",
+                 fontsize=13, pad=20)
+
+    save(fig, output_dir, "pipeline_table.png")
+
+
+# ── main ──────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="designer_git benchmark plots")
+    parser.add_argument("--results", default="results",
+                        help="Directory with CSV result files")
+    parser.add_argument("--output", default="graphs",
+                        help="Directory to save graph images")
+    args = parser.parse_args()
+
+    print(f"results: {args.results}")
+    print(f"output:  {args.output}")
+
+    plot_scenario1_rolling_hash(args.results, args.output)
+    plot_scenario2_storage(args.results, args.output)
+    plot_scenario3_texture(args.results, args.output)
+    plot_scenario7_fallback(args.results, args.output)
+    plot_scenario8_theory(args.results, args.output)
+    plot_pipeline_table(args.output)
+
+    print("\nAll plots done.")
+
+
+if __name__ == "__main__":
+    main()
+
+
+# python3 benchmark/plot.py --results benchmark/results --output benchmark/graphs
+
+# 생성되는 그래프
+# scenario1_rolling_hash.png  ← Rolling Hash vs 고정 청크
+# scenario2_storage.png       ← Git LFS vs designer-git 누적 크기
+# scenario3_texture.png       ← 텍스처 In-place 절감률
+# scenario7_fallback.png      ← 압축 포맷 fullcopy 확인
+# scenario8_theory.png        ← 1바이트 수정 이론치
+# pipeline_table.png          ← 파이프라인 단계별 적용 가능성 표

--- a/benchmark/quick_perf.py
+++ b/benchmark/quick_perf.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+designer_git quick performance test
+1GB 파일 1회 측정 — 빠른 성능 확인용
+
+Usage:
+    sudo python3 quick_perf.py --dgit ./build/dgit
+"""
+
+import os
+import time
+import shutil
+import argparse
+import subprocess
+from pathlib import Path
+
+REPO_DIR = Path("_quick_bench")
+
+
+def drop_os_caches():
+    subprocess.run("sync && echo 3 > /proc/sys/vm/drop_caches",
+                   shell=True, check=False)
+
+
+def run(cmd, cwd=None):
+    drop_os_caches()
+    start = time.perf_counter()
+    result = subprocess.run(cmd, shell=True, cwd=cwd,
+                            capture_output=True, text=True)
+    elapsed = time.perf_counter() - start
+    return result.returncode, result.stdout, result.stderr, elapsed
+
+
+def make_exr(path, size_mb):
+    header = bytes([0x76, 0x2F, 0x31, 0x01])
+    with open(path, "wb") as f:
+        f.write(header)
+        remaining = size_mb * 1024 * 1024 - len(header)
+        for _ in range(remaining // (1024 * 1024)):
+            f.write(os.urandom(1024 * 1024))
+        f.write(os.urandom(remaining % (1024 * 1024)))
+
+
+def setup_repo(dgit, repo_path):
+    if repo_path.exists():
+        shutil.rmtree(repo_path)
+    repo_path.mkdir(parents=True)
+    subprocess.run(f"{dgit} init", shell=True, cwd=repo_path,
+                   capture_output=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Quick perf test")
+    parser.add_argument("--dgit", required=True)
+    parser.add_argument("--size", type=int, default=1024,
+                        help="File size in MB (default: 1024 = 1GB)")
+    args = parser.parse_args()
+
+    dgit = str(Path(args.dgit).resolve())
+    size_mb = args.size
+
+    print(f"dgit: {dgit}")
+    print(f"file size: {size_mb}MB")
+    print(f"{'='*50}")
+
+    repo = REPO_DIR
+    setup_repo(dgit, repo)
+    src = repo / "texture.exr"
+
+    print(f"1. Generating {size_mb}MB exr file ... ", end="", flush=True)
+    t0 = time.perf_counter()
+    make_exr(src, size_mb)
+    print(f"{time.perf_counter()-t0:.2f}s")
+
+    print(f"2. Initial commit (base) ... ", end="", flush=True)
+    subprocess.run(f"{dgit} add texture.exr", shell=True, cwd=repo,
+                   capture_output=True)
+    _, _, _, t = run(f"{dgit} commit -m init texture.exr", cwd=repo)
+    print(f"{t:.3f}s")
+
+    print(f"3. Modifying 1 byte at middle ... ", end="", flush=True)
+    size = os.path.getsize(src)
+    with open(src, "r+b") as f:
+        f.seek(size // 2)
+        f.write(b"\x42")
+    print("done")
+
+    print(f"4. Commit (delta) ... ", end="", flush=True)
+    _, _, _, commit_t = run(f"{dgit} commit -m modify texture.exr", cwd=repo)
+    print(f"{commit_t:.3f}s")
+
+    # delta 크기
+    deltas = repo / ".vcs" / "objects" / "deltas"
+    delta_kb = sum(f.stat().st_size for f in deltas.rglob("*") if f.is_file()) / 1024
+    savings = (1 - delta_kb / (size_mb * 1024)) * 100
+    print(f"   delta size: {delta_kb:.1f}KB  savings: {savings:.2f}%")
+
+    print(f"5. Checkout ... ", end="", flush=True)
+    head = (repo / ".vcs" / "HEAD").read_text().strip()
+    _, _, _, checkout_t = run(f"{dgit} checkout {head}", cwd=repo)
+    print(f"{checkout_t:.3f}s")
+
+    print(f"{'='*50}")
+    print(f"Results ({size_mb}MB file):")
+    print(f"  commit time:   {commit_t:.3f}s")
+    print(f"  checkout time: {checkout_t:.3f}s")
+    print(f"  delta size:    {delta_kb:.1f}KB")
+    print(f"  savings:       {savings:.2f}%")
+
+    shutil.rmtree(repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engine/delta.cpp
+++ b/src/engine/delta.cpp
@@ -10,6 +10,15 @@
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+#include <openssl/evp.h>
+#include <sstream>
+#include <iomanip>
 
 namespace fs = std::filesystem;
 
@@ -17,7 +26,7 @@ namespace fs = std::filesystem;
 static const size_t   IO_BUF_SIZE  = 4  * 1024 * 1024; // 4MB I/O 버퍼 (디스크 읽기 단위)
 static const size_t   MIN_CHUNK    = 4  * 1024;          // 최소 블록 4KB  (과분할 방지)
 static const size_t   MAX_CHUNK    = 64 * 1024;          // 최대 블록 64KB (과대 청크 방지)
-static const size_t   WINDOW_SIZE  = 48;                 // 슬라이딩 윈도우 (경계 안정성 ↔ 비용 균형)
+static const size_t   WINDOW_SIZE  = 64;                 // 슬라이딩 윈도우 (경계 안정성 ↔ 비용 균형)
 static const uint64_t CDC_BASE     = 257ULL;             // 롤링 해시 기저 (CDC 경계 탐지용)
 //static const uint64_t CDC_MOD      = 1000000007ULL;      // 롤링 해시 모듈러
 static const uint64_t CDC_MASK     = 16383ULL;           // (2^14-1): P(hit)≈1/16384 → 평균 ~16KB 블록
@@ -96,8 +105,7 @@ struct CdcState {
         if (ring_count < WINDOW_SIZE) ++ring_count;
 
         ring[ring_head] = b;
-        ring_head = (ring_head + 1 < static_cast<int>(WINDOW_SIZE))
-                    ? ring_head + 1 : 0; // 분기문이 % 보다 빠름
+        ring_head = (ring_head + 1) & 63;
 
         rolling = rolling * CDC_BASE + b - (removed * POW_BASE_WIN);
     }
@@ -252,7 +260,8 @@ static int process_file_b(
 // ── delta_create ──────────────────────────────────────────────
 int delta_create(const char* path_a,
                  const char* path_b,
-                 const char* out_delta) {
+                 const char* out_delta,
+                 std::string* out_sha256) {
 
     // 1단계: 파일 A CDC 분할 → 해시맵 구성 (싱글스레드, 순차)
     std::unordered_map<BlockHash, std::pair<uint64_t, uint64_t>, BlockHasher> hash_map;
@@ -288,41 +297,64 @@ int delta_create(const char* path_a,
 
     // ── Producer ─────────────────────────────────────────────
     auto producer = [&]() {
-    std::ifstream file(path_b, std::ios::binary);
-    if (!file) {
+        std::ifstream file(path_b, std::ios::binary);
+        if (!file) {
+            std::unique_lock<std::mutex> lk(mtx);
+            producer_done = true;
+            cv_full.notify_all();
+            return;
+        }
+
+        // SHA256 컨텍스트 초기화
+        EVP_MD_CTX* sha_ctx = nullptr;
+        if (out_sha256) {
+            sha_ctx = EVP_MD_CTX_new();
+            EVP_DigestInit_ex(sha_ctx, EVP_sha256(), nullptr);
+        }
+
+        int idx = 0;
+        while (true) {
+            {
+                std::unique_lock<std::mutex> lk(mtx);
+                cv_empty.wait(lk, [&]{ return buf_state[idx] == 0; });
+            }
+
+            file.read(reinterpret_cast<char*>(bufs[idx].data()), IO_BUF_SIZE);
+            size_t n = static_cast<size_t>(file.gcount());
+
+            // 읽은 데이터를 SHA256에 피기배킹
+            if (sha_ctx && n > 0)
+                EVP_DigestUpdate(sha_ctx, bufs[idx].data(), n);
+
+            {
+                std::unique_lock<std::mutex> lk(mtx);
+                buf_sizes[idx] = n;
+                buf_state[idx] = 1;
+                cv_full.notify_one();
+            }
+
+            if (n == 0) break;
+            idx = (idx + 1) % NUM_BUFS;
+        }
+
+        // SHA256 최종화
+        if (sha_ctx && out_sha256) {
+            unsigned char digest[EVP_MAX_MD_SIZE];
+            unsigned int digest_len = 0;
+            EVP_DigestFinal_ex(sha_ctx, digest, &digest_len);
+            EVP_MD_CTX_free(sha_ctx);
+
+            std::ostringstream oss;
+            for (unsigned int i = 0; i < digest_len; ++i)
+                oss << std::hex << std::setw(2) << std::setfill('0')
+                    << static_cast<int>(digest[i]);
+            *out_sha256 = oss.str();
+        }
+
         std::unique_lock<std::mutex> lk(mtx);
         producer_done = true;
         cv_full.notify_all();
-        return;
-    }
-
-    int idx = 0;
-    while (true) {
-        // 슬롯이 빌 때까지 먼저 대기
-        {
-            std::unique_lock<std::mutex> lk(mtx);
-            cv_empty.wait(lk, [&]{ return buf_state[idx] == 0; });
-        }
-
-        // 슬롯 비어있음 확인 후 디스크 읽기
-        file.read(reinterpret_cast<char*>(bufs[idx].data()), IO_BUF_SIZE);
-        size_t n = static_cast<size_t>(file.gcount());
-
-        {
-            std::unique_lock<std::mutex> lk(mtx);
-            buf_sizes[idx] = n;
-            buf_state[idx] = 1;
-            cv_full.notify_one();
-        }
-
-        if (n == 0) break;
-        idx = (idx + 1) % NUM_BUFS;
-    }
-
-    std::unique_lock<std::mutex> lk(mtx);
-    producer_done = true;
-    cv_full.notify_all();
-};
+    };
 
     // ── Consumer ─────────────────────────────────────────────
     auto consumer = [&]() {
@@ -425,25 +457,60 @@ int delta_apply(const char* path_base,
                 const char* path_delta,
                 const char* out_file) {
 
-    std::ifstream base(path_base, std::ios::binary);
-    if (!base) return ERR_OPEN_SRC;
+    // base 파일 mmap
+    int base_fd = open(path_base, O_RDONLY);
+    if (base_fd < 0) return ERR_OPEN_SRC;
+
+    struct stat base_st;
+    if (fstat(base_fd, &base_st) < 0) { close(base_fd); return ERR_OPEN_SRC; }
+    size_t base_size = static_cast<size_t>(base_st.st_size);
+
+    const uint8_t* base_ptr = nullptr;
+    if (base_size > 0) {
+        base_ptr = static_cast<const uint8_t*>(
+            mmap(nullptr, base_size, PROT_READ, MAP_PRIVATE, base_fd, 0));
+        if (base_ptr == MAP_FAILED) { close(base_fd); return ERR_OPEN_SRC; }
+        // 순차 읽기 힌트 → OS가 캐시 페이징 최소화
+        madvise((void*)base_ptr, base_size, MADV_SEQUENTIAL);
+    }
+    close(base_fd);
 
     std::ifstream delta_f(path_delta, std::ios::binary);
-    if (!delta_f) return ERR_OPEN_DELTA;
+    if (!delta_f) {
+        if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+        return ERR_OPEN_DELTA;
+    }
 
     std::ofstream out(out_file, std::ios::binary);
-    if (!out) return ERR_OPEN_OUT;
+    if (!out) {
+        if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+        return ERR_OPEN_OUT;
+    }
+
+    // 1MB 쓰기 버퍼
+    std::vector<char> write_buf(1024 * 1024);
+    out.rdbuf()->pubsetbuf(write_buf.data(), write_buf.size());
 
     // 헤더 검증: magic + version
     char     magic[8]   = {};
     uint32_t version    = 0;
-    if (!delta_f.read(magic, sizeof(magic)))         return ERR_TRUNCATED_DELTA;
-    if (std::memcmp(magic, DELTA_MAGIC, 8) != 0)     return ERR_BAD_MAGIC;
-    if (!delta_f.read(reinterpret_cast<char*>(&version),
-                      sizeof(version)))               return ERR_TRUNCATED_DELTA;
-    if (version != DELTA_VERSION)                    return ERR_BAD_VERSION;
+    if (!delta_f.read(magic, sizeof(magic))) {
+        if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+        return ERR_TRUNCATED_DELTA;
+    }
+    if (std::memcmp(magic, DELTA_MAGIC, 8) != 0) {
+        if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+        return ERR_BAD_MAGIC;
+    }
+    if (!delta_f.read(reinterpret_cast<char*>(&version), sizeof(version))) {
+        if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+        return ERR_TRUNCATED_DELTA;
+    }
+    if (version != DELTA_VERSION) {
+        if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+        return ERR_BAD_VERSION;
+    }
 
-    // 가변 크기 블록용 읽기 버퍼 (재사용)
     std::vector<uint8_t> buf;
     buf.reserve(MAX_CHUNK);
 
@@ -451,47 +518,64 @@ int delta_apply(const char* path_base,
     while (delta_f.read(reinterpret_cast<char*>(&cmd), sizeof(cmd))) {
 
         if (cmd == CMD_COPY) {
-            // COPY: on-disk 포맷은 uint64_t (이식성 보장)
             uint64_t src_off = 0, src_len = 0;
-            if (!delta_f.read(reinterpret_cast<char*>(&src_off), sizeof(src_off))) return ERR_TRUNCATED_DELTA;
-            if (!delta_f.read(reinterpret_cast<char*>(&src_len), sizeof(src_len))) return ERR_TRUNCATED_DELTA;
+            if (!delta_f.read(reinterpret_cast<char*>(&src_off), sizeof(src_off))) {
+                if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+                return ERR_TRUNCATED_DELTA;
+            }
+            if (!delta_f.read(reinterpret_cast<char*>(&src_len), sizeof(src_len))) {
+                if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+                return ERR_TRUNCATED_DELTA;
+            }
 
-            // 길이 상한 검증 (악성/손상 delta 방어)
-            if (src_len == 0 || src_len > MAX_VALID_LEN) return ERR_INVALID_LEN;
+            if (src_len == 0 || src_len > MAX_VALID_LEN) {
+                if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+                return ERR_INVALID_LEN;
+            }
+            if (src_off + src_len > base_size) {
+                if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+                return ERR_BASE_READ;
+            }
 
-            buf.resize(static_cast<size_t>(src_len));
-            base.seekg(static_cast<std::streamoff>(src_off));
-            if (!base) return ERR_BASE_READ;
-
-            base.read(reinterpret_cast<char*>(buf.data()),
-                      static_cast<std::streamsize>(src_len));
-            // 요청한 바이트 수만큼 정확히 읽혔는지 검증
-            if (static_cast<uint64_t>(base.gcount()) != src_len) return ERR_BASE_READ;
-
-            if (!out.write(reinterpret_cast<const char*>(buf.data()),
-                           static_cast<std::streamsize>(src_len))) return ERR_OUT_WRITE;
+            // mmap 포인터로 직접 write → seekg 오버헤드 없음
+            if (!out.write(reinterpret_cast<const char*>(base_ptr + src_off),
+                           static_cast<std::streamsize>(src_len))) {
+                if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+                return ERR_OUT_WRITE;
+            }
 
         } else if (cmd == CMD_INSERT) {
             uint64_t len = 0;
-            if (!delta_f.read(reinterpret_cast<char*>(&len), sizeof(len))) return ERR_TRUNCATED_DELTA;
+            if (!delta_f.read(reinterpret_cast<char*>(&len), sizeof(len))) {
+                if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+                return ERR_TRUNCATED_DELTA;
+            }
 
-            // 길이 상한 검증
-            if (len == 0 || len > MAX_VALID_LEN) return ERR_INVALID_LEN;
+            if (len == 0 || len > MAX_VALID_LEN) {
+                if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+                return ERR_INVALID_LEN;
+            }
 
             buf.resize(static_cast<size_t>(len));
             delta_f.read(reinterpret_cast<char*>(buf.data()),
                          static_cast<std::streamsize>(len));
-            // 요청한 바이트 수만큼 정확히 읽혔는지 검증
-            if (static_cast<uint64_t>(delta_f.gcount()) != len) return ERR_TRUNCATED_DELTA;
+            if (static_cast<uint64_t>(delta_f.gcount()) != len) {
+                if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+                return ERR_TRUNCATED_DELTA;
+            }
 
             if (!out.write(reinterpret_cast<const char*>(buf.data()),
-                           static_cast<std::streamsize>(len))) return ERR_OUT_WRITE;
+                           static_cast<std::streamsize>(len))) {
+                if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
+                return ERR_OUT_WRITE;
+            }
 
         } else {
-            // 알 수 없는 cmd → 손상된 delta 파일로 판단, 즉시 중단
+            if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
             return ERR_BAD_CMD;
         }
     }
 
+    if (base_ptr) munmap(const_cast<uint8_t*>(base_ptr), base_size);
     return DELTA_OK;
 }

--- a/src/engine/delta.h
+++ b/src/engine/delta.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <string>
 
 // ── 오류 코드 ─────────────────────────────────────────────────
 // CLI에서 원인별 메시지 출력에 활용
@@ -43,7 +44,8 @@ enum DeltaError {
  */
 int delta_create(const char* path_a,
                  const char* path_b,
-                 const char* out_delta);
+                 const char* out_delta,
+                 std::string* out_sha256 = nullptr);
 
 /**
  * delta_apply

--- a/src/engine/format.cpp
+++ b/src/engine/format.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <vector>
 
-static const size_t SAMPLE_BLOCK = 4 + 1024 * 1024;        // 4MB 블록 단위
+static const size_t SAMPLE_BLOCK = 4 * 1024 * 1024;        // 4MB 블록 단위
 static const size_t SAMPLE_REGION = 100 * 1024 * 1024; // 100MB 구간
 
 // 앞 16바이트만 읽으면 모든 헤더 판별 가능

--- a/src/engine/format.cpp
+++ b/src/engine/format.cpp
@@ -3,8 +3,9 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <vector>
 
-static const size_t SAMPLE_BLOCK = 16 * 1024;        // 16KB 블록 단위
+static const size_t SAMPLE_BLOCK = 4 + 1024 * 1024;        // 4MB 블록 단위
 static const size_t SAMPLE_REGION = 100 * 1024 * 1024; // 100MB 구간
 
 // 앞 16바이트만 읽으면 모든 헤더 판별 가능
@@ -63,16 +64,16 @@ static size_t count_changed_blocks(std::ifstream& prev_f,
     prev_f.seekg(offset);
     curr_f.seekg(offset);
 
-    uint8_t prev_buf[SAMPLE_BLOCK];
-    uint8_t curr_buf[SAMPLE_BLOCK];
+    std::vector<uint8_t> prev_buf(SAMPLE_BLOCK);
+    std::vector<uint8_t> curr_buf(SAMPLE_BLOCK);
 
     size_t changed = 0;
     size_t scanned = 0;
 
     while (scanned < region_size)
     {
-        prev_f.read(reinterpret_cast<char*>(prev_buf), SAMPLE_BLOCK);
-        curr_f.read(reinterpret_cast<char*>(curr_buf), SAMPLE_BLOCK);
+        prev_f.read(reinterpret_cast<char*>(prev_buf.data()), SAMPLE_BLOCK);
+        curr_f.read(reinterpret_cast<char*>(curr_buf.data()), SAMPLE_BLOCK);
 
         size_t prev_n = static_cast<size_t>(prev_f.gcount());
         size_t curr_n = static_cast<size_t>(curr_f.gcount());
@@ -81,7 +82,7 @@ static size_t count_changed_blocks(std::ifstream& prev_f,
             break;
 
         size_t n = std::min(prev_n, curr_n);
-        if (memcmp(prev_buf, curr_buf, n) != 0)
+        if (memcmp(prev_buf.data(), curr_buf.data(), n) != 0)
             ++changed;
 
         scanned += n;

--- a/src/vcs/vcs.cpp
+++ b/src/vcs/vcs.cpp
@@ -403,8 +403,8 @@ std::string commit(const std::string& repo_path, const std::string& message, con
     ss << std::hex << std::setw(16) << std::setfill('0') << hasher(seed);
     std::string commit_id = ss.str();
 
-    // 3. 파일 SHA256
-    std::string file_sha256 = sha256_file(target_file);
+    // 3. 파일 SHA256 — delta 경로가 아닌 경우에만 미리 계산
+    std::string file_sha256;
 
     CommitMetadata meta;
     meta.id = commit_id;
@@ -419,6 +419,7 @@ std::string commit(const std::string& repo_path, const std::string& message, con
     // 4. 최초 커밋: base에 파일 통째로 복사
     if (!fs::exists(base_file))
     {
+        file_sha256 = sha256_file(target_file);
         fs::copy_file(target_file, base_file,
             fs::copy_options::overwrite_existing);
         uint64_t file_size = static_cast<uint64_t>(fs::file_size(target_file));
@@ -429,6 +430,7 @@ std::string commit(const std::string& repo_path, const std::string& message, con
         // 압축 포맷이면 delta 대신 전체 저장 (Git LFS 방식과 동일)
         if (is_compressed_format(target_file))
         {
+            file_sha256 = sha256_file(target_file);
             fs::copy_file(target_file, base_file,
                 fs::copy_options::overwrite_existing);
             uint64_t file_size = static_cast<uint64_t>(fs::file_size(target_file));
@@ -481,7 +483,8 @@ std::string commit(const std::string& repo_path, const std::string& message, con
             {
                 int ret = delta_create(prev_file.string().c_str(),
                     target_file.c_str(),
-                    delta_path.string().c_str());
+                    delta_path.string().c_str(),
+                    &file_sha256);
 
                 /* parent_id가 비어 있으면 위의 분기에서 prev_file = base_file 을 그대로
                 가리키고 있으므로, 임시 복원 파일이 생성된 적이 없다.즉, 삭제 대상이 없다.
@@ -593,20 +596,15 @@ int checkout(const std::string& repo_path, const std::string& commit_id)
         }
         else
         {
-            // delta 체인 순차 적용
-            // tmp_a: 현재 복원 중간 결과, tmp_b: delta 적용 후 출력
-            fs::path tmp_a = vcs_path / ("tmp_a_" + commit_id);
-            fs::path tmp_b = vcs_path / ("tmp_b_" + commit_id);
-
             // 스냅샷 있으면 스냅샷에서 시작, 없으면 base에서 시작
-            fs::path start_file;
+            // copy_file 없이 포인터만 가리킴
+            fs::path current_base;
             if (!snap_commit_id.empty())
-                start_file = vcs_path / "objects" / "snapshots" / (snap_commit_id + ".snap");
+                current_base = vcs_path / "objects" / "snapshots" / (snap_commit_id + ".snap");
             else
-                start_file = base_file;
+                current_base = base_file;
 
-            fs::copy_file(start_file, tmp_a,
-                          fs::copy_options::overwrite_existing);
+            fs::path start_file = current_base; // 원본 보존용
 
             // chain[0]은 base 커밋(delta 없음), chain[1]부터 delta 적용
             for (size_t i = 1; i < chain.size(); ++i)
@@ -614,7 +612,8 @@ int checkout(const std::string& repo_path, const std::string& commit_id)
                 CommitMetadata cm = load_commit_metadata(repo_path, chain[i]);
                 if (cm.id.empty())
                 {
-                    fs::remove(tmp_a);
+                    if (current_base != start_file && fs::exists(current_base))
+                        fs::remove(current_base);
                     return -1;
                 }
 
@@ -636,27 +635,34 @@ int checkout(const std::string& repo_path, const std::string& commit_id)
                 fs::path delta_path = vcs_path / delta_rel;
                 if (!fs::exists(delta_path))
                 {
-                    fs::remove(tmp_a);
+                    if (current_base != start_file && fs::exists(current_base))
+                        fs::remove(current_base);
                     return -1;
                 }
 
-                // delta 적용: tmp_a(이전) + delta → tmp_b(다음)
-                if (delta_apply(tmp_a.string().c_str(),
-                    delta_path.string().c_str(),
-                    tmp_b.string().c_str()) != 0)
+                // 마지막 delta면 바로 최종 경로로 출력 → copy_file 불필요
+                bool is_last = (i == chain.size() - 1);
+                fs::path target_out = is_last
+                    ? fs::path(fe.path)
+                    : vcs_path / ("tmp_" + commit_id + "_" + std::to_string(i));
+
+                if (delta_apply(current_base.string().c_str(),
+                                delta_path.string().c_str(),
+                                target_out.string().c_str()) != 0)
                 {
-                    fs::remove(tmp_a);
-                    fs::remove(tmp_b);
+                    if (current_base != start_file && fs::exists(current_base))
+                        fs::remove(current_base);
+                    if (fs::exists(target_out))
+                        fs::remove(target_out);
                     return -1;
                 }
 
-                fs::rename(tmp_b, tmp_a); // 다음 단계 입력으로 교체
-            }
+                // 이전 임시 파일 삭제 (원본 start_file은 건드리지 않음)
+                if (current_base != start_file && fs::exists(current_base))
+                    fs::remove(current_base);
 
-            // 최종 결과를 원래 경로에 저장
-            fs::copy_file(tmp_a, fe.path,
-                fs::copy_options::overwrite_existing);
-            fs::remove(tmp_a);
+                current_base = target_out;
+            }
         }
 
         // 4. SHA256 검증


### PR DESCRIPTION
## 작업 내용
- benchmark/quick_perf.py 추가
  1GB 파일 1회 빠른 성능 측정용
  sudo python3 benchmark/quick_perf.py --dgit ./build/dgit

벤치마크 자동화 스크립트
- benchmark/measure.py 작성
  시나리오 1, 2, 3, 6, 7, 8 자동 실행
  파일 생성 / 수정 / dgit 실행 / CSV 저장
  OS 페이지 캐시 플러시 (측정값 왜곡 방지)
  3회 반복 평균

- benchmark/plot.py 작성
  CSV → 그래프 자동 생성 (matplotlib)
  누적 저장소 크기 (로그 스케일)
  Rolling Hash vs 고정 청크 비교
  텍스처 In-place 절감률
  압축 포맷 fullcopy 확인
  1바이트 수정 이론치
  파이프라인 단계별 적용 가능성 표

성능 최적화
- vcs.cpp: checkout() copy_file 제거
  파일 경로 포인터 교체로 불필요한 10GB 복사 제거
  100MB: 9초 → 3.5초 / 1GB: 100초 → 38초

- delta.cpp: delta_apply() mmap 적용
  base 파일 메모리 매핑 + MADV_SEQUENTIAL 힌트
  seekg 랜덤 접근 오버헤드 제거

- delta.cpp: SHA256 피기배킹
  delta_create() 내부에서 동시 계산
  commit 시 파일 이중 읽기 제거

- delta.cpp: WINDOW_SIZE 48 → 64
  조건 분기 제거, 비트 연산으로 교체
  100억 번 분기 예측 실패 원천 차단

- format.cpp: 샘플링 버퍼 16KB → 4MB
  C++ 스트림 호출 횟수 대폭 감소

## 관련 Issue
Closes #40 

## 변경된 파일
- benchmark/measure.py
- benchmark/plot.py
- src/engine/delta.cpp
- src/engine/delta.h
- src/engine/format.cpp
- src/vcs/vcs.cpp
- 
## 체크리스트
- [x] 본인 브랜치에서 작업했다 (feat/benchmark-scripts)
- [x] 커밋 메시지 규칙을 따랐다
- [x] 팀원 1명을 Reviewer로 지정했다
- [x] 코드에 주석을 달았다

## 리뷰어에게
measure.py 실행 방법:
sudo python3 benchmark/measure.py --dgit ./build/dgit --scenarios 1,2,3,6,7,8

plot.py 실행 방법:
python3 benchmark/plot.py --results benchmark/results --output benchmark/graphs

sudo가 필요한 이유: OS 페이지 캐시 플러시에 관리자 권한 필요
성능 최적화는 WSL2 환경 기준이며 Windows 빌드는 기존 방식 유지됩니다.

벤치마크는 반드시 WSL 네이티브 경로(~ /)에서 실행해야 합니다.
/mnt/c/ 경로(Windows 드라이브 마운트)에서 실행 시
I/O 병목으로 측정값이 10~13배 왜곡됩니다.

실험 환경 비교:
/mnt/c/ 기준: 1GB checkout 38초
~/        기준: 1GB checkout 2.8초 (13배 차이)

실험 시 주의사항:
1. ~/designer_git 으로 프로젝트 복사
2. sudo python3 benchmark/measure.py 로 실행 (캐시 플러시 권한 필요)